### PR TITLE
feat: 인증 모듈 (_auth.py) 구현

### DIFF
--- a/src/upbeat/__init__.py
+++ b/src/upbeat/__init__.py
@@ -1,3 +1,4 @@
+from upbeat._auth import Credentials
 from upbeat._constants import (
     API_BASE_URL,
     MarketState,
@@ -31,6 +32,8 @@ from upbeat._errors import (
 )
 
 __all__ = [
+    # Auth
+    "Credentials",
     # Constants
     "API_BASE_URL",
     "MarketState",

--- a/src/upbeat/_auth.py
+++ b/src/upbeat/_auth.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from urllib.parse import unquote, urlencode
+
+import jwt
+
+
+class Credentials:
+    access_key: str
+    secret_key: str
+
+    def __init__(self, access_key: str, secret_key: str) -> None:
+        if not access_key or not access_key.strip():
+            raise ValueError("access_key must not be empty or blank")
+        if not secret_key or not secret_key.strip():
+            raise ValueError("secret_key must not be empty or blank")
+        if " " in access_key or "\t" in access_key:
+            raise ValueError("access_key must not contain whitespace")
+        if " " in secret_key or "\t" in secret_key:
+            raise ValueError("secret_key must not contain whitespace")
+        self.access_key = access_key
+        self.secret_key = secret_key
+
+    def __repr__(self) -> str:
+        if len(self.access_key) > 6:
+            masked = f"{self.access_key[:3]}...{self.access_key[-3:]}"
+        else:
+            masked = self.access_key[:1] + "***"
+        return f"Credentials(access_key='{masked}', secret_key='***')"
+
+
+def build_query_string(params: dict[str, object]) -> str:
+    if not params:
+        return ""
+    return unquote(urlencode(params, doseq=True))
+
+
+def build_jwt(credentials: Credentials, query_string: str = "") -> str:
+    payload: dict[str, str] = {
+        "access_key": credentials.access_key,
+        "nonce": str(uuid.uuid4()),
+    }
+
+    if query_string:
+        query_hash = hashlib.sha512(query_string.encode("utf-8")).hexdigest()
+        payload["query_hash"] = query_hash
+        payload["query_hash_alg"] = "SHA512"
+
+    return jwt.encode(payload, credentials.secret_key, algorithm="HS512")
+
+
+def build_auth_header(credentials: Credentials, query_string: str = "") -> str:
+    return f"Bearer {build_jwt(credentials, query_string)}"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,145 @@
+import hashlib
+import uuid
+
+import jwt
+import pytest
+
+from upbeat._auth import (
+    Credentials,
+    build_auth_header,
+    build_jwt,
+    build_query_string,
+)
+
+SECRET = "test-secret-key"
+ACCESS = "test-access-key"
+
+
+# ── Credentials ──────────────────────────────────────────────────────────
+
+
+class TestCredentials:
+    def test_valid_creation(self):
+        creds = Credentials(ACCESS, SECRET)
+        assert creds.access_key == ACCESS
+        assert creds.secret_key == SECRET
+
+    def test_empty_access_key(self):
+        with pytest.raises(ValueError, match="access_key"):
+            Credentials("", SECRET)
+
+    def test_blank_access_key(self):
+        with pytest.raises(ValueError, match="access_key"):
+            Credentials("   ", SECRET)
+
+    def test_empty_secret_key(self):
+        with pytest.raises(ValueError, match="secret_key"):
+            Credentials(ACCESS, "")
+
+    def test_blank_secret_key(self):
+        with pytest.raises(ValueError, match="secret_key"):
+            Credentials(ACCESS, "   ")
+
+    def test_whitespace_in_access_key(self):
+        with pytest.raises(ValueError, match="access_key"):
+            Credentials("key with space", SECRET)
+
+    def test_whitespace_in_secret_key(self):
+        with pytest.raises(ValueError, match="secret_key"):
+            Credentials(ACCESS, "key\twith\ttab")
+
+    def test_repr_masks_secret(self):
+        creds = Credentials(ACCESS, SECRET)
+        r = repr(creds)
+        assert SECRET not in r
+        assert "***" in r
+        assert "tes...key" in r
+
+    def test_repr_short_access_key(self):
+        creds = Credentials("abcdef", SECRET)
+        r = repr(creds)
+        assert "a***" in r
+        assert SECRET not in r
+
+
+# ── build_query_string ───────────────────────────────────────────────────
+
+
+class TestBuildQueryString:
+    def test_simple_params(self):
+        qs = build_query_string({"market": "KRW-BTC", "limit": 10})
+        assert "market=KRW-BTC" in qs
+        assert "limit=10" in qs
+
+    def test_array_params(self):
+        qs = build_query_string({"states[]": ["wait", "watch"]})
+        assert qs == "states[]=wait&states[]=watch"
+
+    def test_mixed_params(self):
+        qs = build_query_string(
+            {"market": "KRW-BTC", "states[]": ["wait", "watch"]}
+        )
+        assert "market=KRW-BTC" in qs
+        assert "states[]=wait" in qs
+        assert "states[]=watch" in qs
+
+    def test_empty_dict(self):
+        assert build_query_string({}) == ""
+
+
+# ── build_jwt ────────────────────────────────────────────────────────────
+
+
+class TestBuildJwt:
+    def test_without_query_string(self):
+        creds = Credentials(ACCESS, SECRET)
+        token = build_jwt(creds)
+        payload = jwt.decode(token, SECRET, algorithms=["HS512"])
+        assert payload["access_key"] == ACCESS
+        assert "nonce" in payload
+        uuid.UUID(payload["nonce"])  # valid UUID4
+        assert "query_hash" not in payload
+        assert "query_hash_alg" not in payload
+
+    def test_with_query_string(self):
+        creds = Credentials(ACCESS, SECRET)
+        qs = "market=KRW-BTC&limit=10"
+        token = build_jwt(creds, qs)
+        payload = jwt.decode(token, SECRET, algorithms=["HS512"])
+        assert payload["access_key"] == ACCESS
+        assert payload["query_hash_alg"] == "SHA512"
+        expected_hash = hashlib.sha512(qs.encode("utf-8")).hexdigest()
+        assert payload["query_hash"] == expected_hash
+
+    def test_nonce_is_unique(self):
+        creds = Credentials(ACCESS, SECRET)
+        t1 = build_jwt(creds)
+        t2 = build_jwt(creds)
+        p1 = jwt.decode(t1, SECRET, algorithms=["HS512"])
+        p2 = jwt.decode(t2, SECRET, algorithms=["HS512"])
+        assert p1["nonce"] != p2["nonce"]
+
+
+# ── build_auth_header ────────────────────────────────────────────────────
+
+
+class TestBuildAuthHeader:
+    def test_bearer_prefix(self):
+        creds = Credentials(ACCESS, SECRET)
+        header = build_auth_header(creds)
+        assert header.startswith("Bearer ")
+
+    def test_valid_jwt_in_header(self):
+        creds = Credentials(ACCESS, SECRET)
+        header = build_auth_header(creds)
+        token = header.removeprefix("Bearer ")
+        payload = jwt.decode(token, SECRET, algorithms=["HS512"])
+        assert payload["access_key"] == ACCESS
+
+    def test_with_query_string(self):
+        creds = Credentials(ACCESS, SECRET)
+        qs = "market=KRW-BTC"
+        header = build_auth_header(creds, qs)
+        token = header.removeprefix("Bearer ")
+        payload = jwt.decode(token, SECRET, algorithms=["HS512"])
+        assert "query_hash" in payload


### PR DESCRIPTION
## Summary

- `Credentials` 클래스: access_key/secret_key 저장, 빈 문자열·공백 검증, `__repr__` 시크릿 마스킹
- `build_query_string()`: `urllib.parse.urlencode` + `unquote`로 배열 파라미터(`states[]`) 지원
- `build_jwt()`: UUID4 nonce, 쿼리 있을 시 SHA-512 해시 포함, HS512 서명
- `build_auth_header()`: `Bearer {jwt}` 형태 반환
- `__init__.py`에 `Credentials` export 추가
- 19개 테스트 케이스 (`tests/test_auth.py`)

Closes #5

## Test plan

- [x] `uv run pytest tests/test_auth.py -v` — 19 tests passed
- [x] `uv run ruff check src/upbeat/_auth.py tests/test_auth.py` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)