### PR TITLE
feat: add config and logger modules

### DIFF
--- a/src/upbeat/__init__.py
+++ b/src/upbeat/__init__.py
@@ -1,4 +1,5 @@
 from upbeat._auth import Credentials
+from upbeat._config import DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT, Timeout, UpbeatConfig
 from upbeat._constants import (
     API_BASE_URL,
     MarketState,
@@ -9,6 +10,16 @@ from upbeat._constants import (
     TimeInForce,
     get_krw_tick_size,
     round_to_tick,
+)
+from upbeat._logger import (
+    DefaultLogger,
+    ErrorInfo,
+    Logger,
+    NullLogger,
+    RequestInfo,
+    ResponseInfo,
+    RetryInfo,
+    WebSocketEventInfo,
 )
 from upbeat._errors import (
     APIConnectionError,
@@ -34,6 +45,11 @@ from upbeat._errors import (
 __all__ = [
     # Auth
     "Credentials",
+    # Config
+    "DEFAULT_MAX_RETRIES",
+    "DEFAULT_TIMEOUT",
+    "Timeout",
+    "UpbeatConfig",
     # Constants
     "API_BASE_URL",
     "MarketState",
@@ -44,6 +60,15 @@ __all__ = [
     "TimeInForce",
     "get_krw_tick_size",
     "round_to_tick",
+    # Logger
+    "DefaultLogger",
+    "ErrorInfo",
+    "Logger",
+    "NullLogger",
+    "RequestInfo",
+    "ResponseInfo",
+    "RetryInfo",
+    "WebSocketEventInfo",
     # Errors
     "APIConnectionError",
     "APIError",

--- a/src/upbeat/_config.py
+++ b/src/upbeat/_config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Timeout:
+    connect: float = 10.0
+    read: float = 30.0
+
+
+DEFAULT_TIMEOUT = Timeout()
+DEFAULT_MAX_RETRIES = 3
+
+
+@dataclass(frozen=True, slots=True)
+class UpbeatConfig:
+    timeout: Timeout = DEFAULT_TIMEOUT
+    max_retries: int = DEFAULT_MAX_RETRIES
+    auto_throttle: bool = True

--- a/src/upbeat/_logger.py
+++ b/src/upbeat/_logger.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True, slots=True)
+class RequestInfo:
+    method: str
+    url: str
+    headers: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class ResponseInfo:
+    status_code: int
+    url: str
+    headers: dict[str, str]
+    elapsed_ms: float
+
+
+@dataclass(frozen=True, slots=True)
+class RetryInfo:
+    attempt: int
+    max_retries: int
+    delay_seconds: float
+    reason: str
+    method: str
+    url: str
+
+
+@dataclass(frozen=True, slots=True)
+class ErrorInfo:
+    error: Exception
+    method: str
+    url: str
+
+
+@dataclass(frozen=True, slots=True)
+class WebSocketEventInfo:
+    event: str
+    url: str
+    message: str | None = None
+    error: Exception | None = None
+
+
+@runtime_checkable
+class Logger(Protocol):
+    def on_request(self, info: RequestInfo) -> None: ...
+    def on_response(self, info: ResponseInfo) -> None: ...
+    def on_retry(self, info: RetryInfo) -> None: ...
+    def on_error(self, info: ErrorInfo) -> None: ...
+    def on_ws_event(self, info: WebSocketEventInfo) -> None: ...
+
+
+class DefaultLogger:
+    def __init__(self) -> None:
+        self._logger = logging.getLogger("upbeat")
+        self._logger.addHandler(logging.NullHandler())
+
+    def on_request(self, info: RequestInfo) -> None:
+        self._logger.debug("Request: %s %s", info.method, info.url)
+
+    def on_response(self, info: ResponseInfo) -> None:
+        self._logger.debug(
+            "Response: %s %s (%.1fms)", info.status_code, info.url, info.elapsed_ms
+        )
+
+    def on_retry(self, info: RetryInfo) -> None:
+        self._logger.warning(
+            "Retry %s/%s for %s %s in %.1fs: %s",
+            info.attempt,
+            info.max_retries,
+            info.method,
+            info.url,
+            info.delay_seconds,
+            info.reason,
+        )
+
+    def on_error(self, info: ErrorInfo) -> None:
+        self._logger.error("Error on %s %s: %s", info.method, info.url, info.error)
+
+    def on_ws_event(self, info: WebSocketEventInfo) -> None:
+        if info.error is not None:
+            self._logger.warning(
+                "WebSocket %s %s: %s", info.event, info.url, info.error
+            )
+        else:
+            self._logger.debug("WebSocket %s %s", info.event, info.url)
+
+
+class NullLogger:
+    def on_request(self, info: RequestInfo) -> None:
+        pass
+
+    def on_response(self, info: ResponseInfo) -> None:
+        pass
+
+    def on_retry(self, info: RetryInfo) -> None:
+        pass
+
+    def on_error(self, info: ErrorInfo) -> None:
+        pass
+
+    def on_ws_event(self, info: WebSocketEventInfo) -> None:
+        pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from upbeat._config import DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT, Timeout, UpbeatConfig
+
+
+class TestTimeout:
+    def test_defaults(self) -> None:
+        t = Timeout()
+        assert t.connect == 10.0
+        assert t.read == 30.0
+
+    def test_custom_values(self) -> None:
+        t = Timeout(connect=5.0, read=60.0)
+        assert t.connect == 5.0
+        assert t.read == 60.0
+
+    def test_frozen_immutability(self) -> None:
+        t = Timeout()
+        with pytest.raises(AttributeError):
+            t.connect = 99.0  # type: ignore[misc]
+
+
+class TestUpbeatConfig:
+    def test_defaults(self) -> None:
+        config = UpbeatConfig()
+        assert config.timeout == DEFAULT_TIMEOUT
+        assert config.max_retries == DEFAULT_MAX_RETRIES
+        assert config.auto_throttle is True
+
+    def test_custom_values(self) -> None:
+        custom_timeout = Timeout(connect=1.0, read=2.0)
+        config = UpbeatConfig(
+            timeout=custom_timeout, max_retries=5, auto_throttle=False
+        )
+        assert config.timeout.connect == 1.0
+        assert config.max_retries == 5
+        assert config.auto_throttle is False
+
+    def test_partial_custom(self) -> None:
+        config = UpbeatConfig(max_retries=10)
+        assert config.timeout == DEFAULT_TIMEOUT
+        assert config.max_retries == 10
+        assert config.auto_throttle is True
+
+    def test_frozen_immutability(self) -> None:
+        config = UpbeatConfig()
+        with pytest.raises(AttributeError):
+            config.max_retries = 99  # type: ignore[misc]

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from upbeat._logger import (
+    DefaultLogger,
+    ErrorInfo,
+    Logger,
+    NullLogger,
+    RequestInfo,
+    ResponseInfo,
+    RetryInfo,
+    WebSocketEventInfo,
+)
+
+
+class TestContextTypes:
+    def test_request_info(self) -> None:
+        info = RequestInfo(method="GET", url="https://api.upbit.com", headers={"a": "b"})
+        assert info.method == "GET"
+        assert info.url == "https://api.upbit.com"
+        assert info.headers == {"a": "b"}
+
+    def test_response_info(self) -> None:
+        info = ResponseInfo(
+            status_code=200,
+            url="https://api.upbit.com",
+            headers={"x": "y"},
+            elapsed_ms=12.5,
+        )
+        assert info.status_code == 200
+        assert info.elapsed_ms == 12.5
+
+    def test_retry_info(self) -> None:
+        info = RetryInfo(
+            attempt=1,
+            max_retries=3,
+            delay_seconds=1.0,
+            reason="rate limit",
+            method="POST",
+            url="https://api.upbit.com",
+        )
+        assert info.attempt == 1
+        assert info.reason == "rate limit"
+
+    def test_error_info(self) -> None:
+        err = ValueError("test")
+        info = ErrorInfo(error=err, method="GET", url="https://api.upbit.com")
+        assert info.error is err
+
+    def test_ws_event_info_defaults(self) -> None:
+        info = WebSocketEventInfo(event="open", url="wss://api.upbit.com")
+        assert info.message is None
+        assert info.error is None
+
+    def test_ws_event_info_with_optionals(self) -> None:
+        err = ConnectionError("closed")
+        info = WebSocketEventInfo(
+            event="error", url="wss://api.upbit.com", message="fail", error=err
+        )
+        assert info.message == "fail"
+        assert info.error is err
+
+    def test_frozen_immutability(self) -> None:
+        info = RequestInfo(method="GET", url="https://api.upbit.com", headers={})
+        with pytest.raises(AttributeError):
+            info.method = "POST"  # type: ignore[misc]
+
+
+class TestLoggerProtocol:
+    def test_default_logger_is_logger(self) -> None:
+        assert isinstance(DefaultLogger(), Logger)
+
+    def test_null_logger_is_logger(self) -> None:
+        assert isinstance(NullLogger(), Logger)
+
+    def test_custom_class_implements_logger(self) -> None:
+        class CustomLogger:
+            def on_request(self, info: RequestInfo) -> None:
+                pass
+
+            def on_response(self, info: ResponseInfo) -> None:
+                pass
+
+            def on_retry(self, info: RetryInfo) -> None:
+                pass
+
+            def on_error(self, info: ErrorInfo) -> None:
+                pass
+
+            def on_ws_event(self, info: WebSocketEventInfo) -> None:
+                pass
+
+        assert isinstance(CustomLogger(), Logger)
+
+    def test_non_conforming_class(self) -> None:
+        class NotALogger:
+            pass
+
+        assert not isinstance(NotALogger(), Logger)
+
+
+class TestDefaultLogger:
+    def test_on_request_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        logger = DefaultLogger()
+        with caplog.at_level(logging.DEBUG, logger="upbeat"):
+            logger.on_request(
+                RequestInfo(method="GET", url="https://api.upbit.com", headers={})
+            )
+        assert "Request: GET https://api.upbit.com" in caplog.text
+
+    def test_on_response_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        logger = DefaultLogger()
+        with caplog.at_level(logging.DEBUG, logger="upbeat"):
+            logger.on_response(
+                ResponseInfo(
+                    status_code=200,
+                    url="https://api.upbit.com",
+                    headers={},
+                    elapsed_ms=15.3,
+                )
+            )
+        assert "200" in caplog.text
+        assert "15.3ms" in caplog.text
+
+    def test_on_retry_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        logger = DefaultLogger()
+        with caplog.at_level(logging.WARNING, logger="upbeat"):
+            logger.on_retry(
+                RetryInfo(
+                    attempt=2,
+                    max_retries=3,
+                    delay_seconds=1.5,
+                    reason="server error",
+                    method="POST",
+                    url="https://api.upbit.com",
+                )
+            )
+        assert "Retry 2/3" in caplog.text
+        assert "server error" in caplog.text
+
+    def test_on_error_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        logger = DefaultLogger()
+        with caplog.at_level(logging.ERROR, logger="upbeat"):
+            logger.on_error(
+                ErrorInfo(
+                    error=RuntimeError("boom"),
+                    method="GET",
+                    url="https://api.upbit.com",
+                )
+            )
+        assert "boom" in caplog.text
+
+    def test_on_ws_event_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        logger = DefaultLogger()
+        with caplog.at_level(logging.DEBUG, logger="upbeat"):
+            logger.on_ws_event(
+                WebSocketEventInfo(event="open", url="wss://api.upbit.com")
+            )
+        assert "WebSocket open" in caplog.text
+
+    def test_on_ws_event_with_error_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        logger = DefaultLogger()
+        with caplog.at_level(logging.WARNING, logger="upbeat"):
+            logger.on_ws_event(
+                WebSocketEventInfo(
+                    event="error",
+                    url="wss://api.upbit.com",
+                    error=ConnectionError("lost"),
+                )
+            )
+        assert "lost" in caplog.text
+
+
+class TestNullLogger:
+    def test_all_methods_return_none(self) -> None:
+        logger = NullLogger()
+        req = RequestInfo(method="GET", url="https://api.upbit.com", headers={})
+        resp = ResponseInfo(
+            status_code=200, url="https://api.upbit.com", headers={}, elapsed_ms=1.0
+        )
+        retry = RetryInfo(
+            attempt=1,
+            max_retries=3,
+            delay_seconds=1.0,
+            reason="err",
+            method="GET",
+            url="https://api.upbit.com",
+        )
+        err = ErrorInfo(
+            error=Exception("x"), method="GET", url="https://api.upbit.com"
+        )
+        ws = WebSocketEventInfo(event="open", url="wss://api.upbit.com")
+
+        assert logger.on_request(req) is None
+        assert logger.on_response(resp) is None
+        assert logger.on_retry(retry) is None
+        assert logger.on_error(err) is None
+        assert logger.on_ws_event(ws) is None


### PR DESCRIPTION
## Summary
- `_logger.py`: Logger Protocol, DefaultLogger(logging 기반), NullLogger, 컨텍스트 dataclass(RequestInfo, ResponseInfo, RetryInfo, ErrorInfo, WebSocketEventInfo)
- `_config.py`: Timeout, UpbeatConfig dataclass와 기본 상수(DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES)
- `__init__.py`에 모든 public API 추가
- 25개 테스트 작성 (모두 통과)

Closes #7

## Test plan
- [x] `uv run pytest tests/test_logger.py tests/test_config.py -v` — 25 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)