### PR TITLE
feat: add main client skeleton (Upbeat / AsyncUpbeat)

### DIFF
--- a/src/upbeat/__init__.py
+++ b/src/upbeat/__init__.py
@@ -1,3 +1,4 @@
+from upbeat._client import AsyncUpbeat, Upbeat
 from upbeat._auth import Credentials
 from upbeat.types.common import APIResponse
 from upbeat._config import DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT, Timeout, UpbeatConfig
@@ -44,6 +45,9 @@ from upbeat._errors import (
 )
 
 __all__ = [
+    # Client
+    "AsyncUpbeat",
+    "Upbeat",
     # Auth
     "Credentials",
     # Types

--- a/src/upbeat/_client.py
+++ b/src/upbeat/_client.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from functools import cached_property
+from typing import Any
+
+import httpx
+
+from upbeat._auth import Credentials
+from upbeat._config import DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT, Timeout
+from upbeat._constants import API_BASE_URL
+from upbeat._http import AsyncTransport, SyncTransport
+from upbeat._logger import Logger
+
+
+# ── API Resource base classes ────────────────────────────────────────────
+
+
+class _SyncAPIResource:
+    def __init__(
+        self, transport: SyncTransport, credentials: Credentials | None
+    ) -> None:
+        self._transport = transport
+        self._credentials = credentials
+
+
+class _AsyncAPIResource:
+    def __init__(
+        self, transport: AsyncTransport, credentials: Credentials | None
+    ) -> None:
+        self._transport = transport
+        self._credentials = credentials
+
+
+# ── Sync API resource stubs ─────────────────────────────────────────────
+
+
+class QuotationAPI(_SyncAPIResource):
+    pass
+
+
+class AccountsAPI(_SyncAPIResource):
+    pass
+
+
+class OrdersAPI(_SyncAPIResource):
+    pass
+
+
+class DepositsAPI(_SyncAPIResource):
+    pass
+
+
+class WithdrawalsAPI(_SyncAPIResource):
+    pass
+
+
+class MarketsAPI(_SyncAPIResource):
+    pass
+
+
+# ── Async API resource stubs ────────────────────────────────────────────
+
+
+class AsyncQuotationAPI(_AsyncAPIResource):
+    pass
+
+
+class AsyncAccountsAPI(_AsyncAPIResource):
+    pass
+
+
+class AsyncOrdersAPI(_AsyncAPIResource):
+    pass
+
+
+class AsyncDepositsAPI(_AsyncAPIResource):
+    pass
+
+
+class AsyncWithdrawalsAPI(_AsyncAPIResource):
+    pass
+
+
+class AsyncMarketsAPI(_AsyncAPIResource):
+    pass
+
+
+# ── Upbeat (sync client) ────────────────────────────────────────────────
+
+
+class Upbeat:
+    _transport: SyncTransport
+    _credentials: Credentials | None
+    _owns_http_client: bool
+    _closed: bool
+
+    def __init__(
+        self,
+        *,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        base_url: str = API_BASE_URL,
+        timeout: Timeout = DEFAULT_TIMEOUT,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        auto_throttle: bool = True,
+        logger: Logger | None = None,
+        http_client: httpx.Client | None = None,
+        event_hooks: dict[str, list[Any]] | None = None,
+    ) -> None:
+        if (access_key is None) != (secret_key is None):
+            raise ValueError(
+                "Both access_key and secret_key must be provided together, or neither."
+            )
+
+        self._credentials = (
+            Credentials(access_key=access_key, secret_key=secret_key)
+            if access_key is not None and secret_key is not None
+            else None
+        )
+
+        self._base_url = base_url
+        self._timeout = timeout
+        self._max_retries = max_retries
+        self._auto_throttle = auto_throttle
+        self._logger = logger
+        self._owns_http_client = http_client is None
+        self._closed = False
+
+        self._transport = SyncTransport(
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=max_retries,
+            auto_throttle=auto_throttle,
+            logger=logger,
+            http_client=http_client,
+            event_hooks=event_hooks,
+        )
+
+    # ── Resource properties ──────────────────────────────────────────
+
+    @cached_property
+    def quotation(self) -> QuotationAPI:
+        return QuotationAPI(self._transport, self._credentials)
+
+    @cached_property
+    def accounts(self) -> AccountsAPI:
+        return AccountsAPI(self._transport, self._credentials)
+
+    @cached_property
+    def orders(self) -> OrdersAPI:
+        return OrdersAPI(self._transport, self._credentials)
+
+    @cached_property
+    def deposits(self) -> DepositsAPI:
+        return DepositsAPI(self._transport, self._credentials)
+
+    @cached_property
+    def withdrawals(self) -> WithdrawalsAPI:
+        return WithdrawalsAPI(self._transport, self._credentials)
+
+    @cached_property
+    def markets(self) -> MarketsAPI:
+        return MarketsAPI(self._transport, self._credentials)
+
+    # ── Lifecycle ────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        if not self._closed and self._owns_http_client:
+            self._transport.close()
+        self._closed = True
+
+    def __enter__(self) -> Upbeat:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+    # ── with_options ─────────────────────────────────────────────────
+
+    def with_options(
+        self,
+        *,
+        max_retries: int | None = None,
+        auto_throttle: bool | None = None,
+        logger: Logger | None = None,
+    ) -> Upbeat:
+        new = Upbeat.__new__(Upbeat)
+        new._credentials = self._credentials
+        new._base_url = self._base_url
+        new._timeout = self._timeout
+        new._max_retries = max_retries if max_retries is not None else self._max_retries
+        new._auto_throttle = (
+            auto_throttle if auto_throttle is not None else self._auto_throttle
+        )
+        new._logger = logger if logger is not None else self._logger
+        new._owns_http_client = False
+        new._closed = False
+
+        new._transport = SyncTransport(
+            base_url=new._base_url,
+            timeout=new._timeout,
+            max_retries=new._max_retries,
+            auto_throttle=new._auto_throttle,
+            logger=new._logger,
+            http_client=self._transport._client,
+        )
+        return new
+
+
+# ── AsyncUpbeat (async client) ───────────────────────────────────────────
+
+
+class AsyncUpbeat:
+    _transport: AsyncTransport
+    _credentials: Credentials | None
+    _owns_http_client: bool
+    _closed: bool
+
+    def __init__(
+        self,
+        *,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        base_url: str = API_BASE_URL,
+        timeout: Timeout = DEFAULT_TIMEOUT,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        auto_throttle: bool = True,
+        logger: Logger | None = None,
+        http_client: httpx.AsyncClient | None = None,
+        event_hooks: dict[str, list[Any]] | None = None,
+    ) -> None:
+        if (access_key is None) != (secret_key is None):
+            raise ValueError(
+                "Both access_key and secret_key must be provided together, or neither."
+            )
+
+        self._credentials = (
+            Credentials(access_key=access_key, secret_key=secret_key)
+            if access_key is not None and secret_key is not None
+            else None
+        )
+
+        self._base_url = base_url
+        self._timeout = timeout
+        self._max_retries = max_retries
+        self._auto_throttle = auto_throttle
+        self._logger = logger
+        self._owns_http_client = http_client is None
+        self._closed = False
+
+        self._transport = AsyncTransport(
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=max_retries,
+            auto_throttle=auto_throttle,
+            logger=logger,
+            http_client=http_client,
+            event_hooks=event_hooks,
+        )
+
+    # ── Resource properties ──────────────────────────────────────────
+
+    @cached_property
+    def quotation(self) -> AsyncQuotationAPI:
+        return AsyncQuotationAPI(self._transport, self._credentials)
+
+    @cached_property
+    def accounts(self) -> AsyncAccountsAPI:
+        return AsyncAccountsAPI(self._transport, self._credentials)
+
+    @cached_property
+    def orders(self) -> AsyncOrdersAPI:
+        return AsyncOrdersAPI(self._transport, self._credentials)
+
+    @cached_property
+    def deposits(self) -> AsyncDepositsAPI:
+        return AsyncDepositsAPI(self._transport, self._credentials)
+
+    @cached_property
+    def withdrawals(self) -> AsyncWithdrawalsAPI:
+        return AsyncWithdrawalsAPI(self._transport, self._credentials)
+
+    @cached_property
+    def markets(self) -> AsyncMarketsAPI:
+        return AsyncMarketsAPI(self._transport, self._credentials)
+
+    # ── Lifecycle ────────────────────────────────────────────────────
+
+    async def aclose(self) -> None:
+        if not self._closed and self._owns_http_client:
+            await self._transport.aclose()
+        self._closed = True
+
+    async def __aenter__(self) -> AsyncUpbeat:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        await self.aclose()
+
+    # ── with_options ─────────────────────────────────────────────────
+
+    def with_options(
+        self,
+        *,
+        max_retries: int | None = None,
+        auto_throttle: bool | None = None,
+        logger: Logger | None = None,
+    ) -> AsyncUpbeat:
+        new = AsyncUpbeat.__new__(AsyncUpbeat)
+        new._credentials = self._credentials
+        new._base_url = self._base_url
+        new._timeout = self._timeout
+        new._max_retries = (
+            max_retries if max_retries is not None else self._max_retries
+        )
+        new._auto_throttle = (
+            auto_throttle if auto_throttle is not None else self._auto_throttle
+        )
+        new._logger = logger if logger is not None else self._logger
+        new._owns_http_client = False
+        new._closed = False
+
+        new._transport = AsyncTransport(
+            base_url=new._base_url,
+            timeout=new._timeout,
+            max_retries=new._max_retries,
+            auto_throttle=new._auto_throttle,
+            logger=new._logger,
+            http_client=self._transport._client,
+        )
+        return new

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from upbeat._auth import Credentials
+from upbeat._client import (
+    AccountsAPI,
+    AsyncAccountsAPI,
+    AsyncDepositsAPI,
+    AsyncMarketsAPI,
+    AsyncOrdersAPI,
+    AsyncQuotationAPI,
+    AsyncUpbeat,
+    AsyncWithdrawalsAPI,
+    DepositsAPI,
+    MarketsAPI,
+    OrdersAPI,
+    QuotationAPI,
+    Upbeat,
+    WithdrawalsAPI,
+)
+from upbeat._constants import API_BASE_URL
+
+
+# ── TestUpbeatCreation ───────────────────────────────────────────────────
+
+
+class TestUpbeatCreation:
+    def test_default_creation_no_credentials(self) -> None:
+        client = Upbeat()
+        assert client._credentials is None
+        assert client._owns_http_client is True
+        client.close()
+
+    def test_creation_with_credentials(self) -> None:
+        client = Upbeat(access_key="test-key", secret_key="test-secret")
+        assert client._credentials is not None
+        assert isinstance(client._credentials, Credentials)
+        assert client._credentials.access_key == "test-key"
+        client.close()
+
+    def test_creation_access_key_only_raises(self) -> None:
+        with pytest.raises(ValueError, match="Both access_key and secret_key"):
+            Upbeat(access_key="test-key")
+
+    def test_creation_secret_key_only_raises(self) -> None:
+        with pytest.raises(ValueError, match="Both access_key and secret_key"):
+            Upbeat(secret_key="test-secret")
+
+    def test_custom_settings(self) -> None:
+        from upbeat._config import Timeout
+
+        custom_timeout = Timeout(connect=5.0, read=15.0)
+        client = Upbeat(
+            timeout=custom_timeout,
+            max_retries=5,
+            auto_throttle=False,
+        )
+        assert client._max_retries == 5
+        assert client._auto_throttle is False
+        assert client._timeout.connect == 5.0
+        client.close()
+
+
+# ── TestUpbeatClose ──────────────────────────────────────────────────────
+
+
+class TestUpbeatClose:
+    def test_close_internal_client(self) -> None:
+        client = Upbeat()
+        client.close()
+        assert client._closed is True
+
+    def test_close_external_client_not_closed(self) -> None:
+        http_client = httpx.Client(base_url=API_BASE_URL)
+        client = Upbeat(http_client=http_client)
+        assert client._owns_http_client is False
+        client.close()
+        # External client should still be usable
+        assert not http_client.is_closed
+        http_client.close()
+
+    def test_close_idempotent(self) -> None:
+        client = Upbeat()
+        client.close()
+        client.close()  # Should not raise
+        assert client._closed is True
+
+
+# ── TestUpbeatContextManager ────────────────────────────────────────────
+
+
+class TestUpbeatContextManager:
+    def test_context_manager_closes(self) -> None:
+        with Upbeat() as client:
+            assert client._closed is False
+        assert client._closed is True
+
+    def test_context_manager_external_client_not_closed(self) -> None:
+        http_client = httpx.Client(base_url=API_BASE_URL)
+        with Upbeat(http_client=http_client) as client:
+            assert client._owns_http_client is False
+        assert not http_client.is_closed
+        http_client.close()
+
+
+# ── TestUpbeatWithOptions ────────────────────────────────────────────────
+
+
+class TestUpbeatWithOptions:
+    def test_shares_http_client(self) -> None:
+        client = Upbeat()
+        new = client.with_options(max_retries=10)
+        assert new._transport._client is client._transport._client
+        assert new._owns_http_client is False
+        client.close()
+
+    def test_overrides_max_retries(self) -> None:
+        client = Upbeat(max_retries=3)
+        new = client.with_options(max_retries=10)
+        assert new._max_retries == 10
+        assert new._transport._max_retries == 10
+        client.close()
+
+    def test_preserves_credentials(self) -> None:
+        client = Upbeat(access_key="test-key", secret_key="test-secret")
+        new = client.with_options(max_retries=1)
+        assert new._credentials is client._credentials
+        client.close()
+
+    def test_overrides_auto_throttle(self) -> None:
+        client = Upbeat(auto_throttle=True)
+        new = client.with_options(auto_throttle=False)
+        assert new._auto_throttle is False
+        client.close()
+
+
+# ── TestUpbeatResources ──────────────────────────────────────────────────
+
+
+class TestUpbeatResources:
+    def test_cached_property_returns_same_instance(self) -> None:
+        client = Upbeat()
+        q1 = client.quotation
+        q2 = client.quotation
+        assert q1 is q2
+        client.close()
+
+    def test_resource_types(self) -> None:
+        client = Upbeat(access_key="test-key", secret_key="test-secret")
+        assert isinstance(client.quotation, QuotationAPI)
+        assert isinstance(client.accounts, AccountsAPI)
+        assert isinstance(client.orders, OrdersAPI)
+        assert isinstance(client.deposits, DepositsAPI)
+        assert isinstance(client.withdrawals, WithdrawalsAPI)
+        assert isinstance(client.markets, MarketsAPI)
+        client.close()
+
+    def test_resources_receive_transport_and_credentials(self) -> None:
+        client = Upbeat(access_key="test-key", secret_key="test-secret")
+        resource = client.quotation
+        assert resource._transport is client._transport
+        assert resource._credentials is client._credentials
+        client.close()
+
+
+# ── TestAsyncUpbeatCreation ──────────────────────────────────────────────
+
+
+class TestAsyncUpbeatCreation:
+    def test_default_creation_no_credentials(self) -> None:
+        client = AsyncUpbeat()
+        assert client._credentials is None
+        assert client._owns_http_client is True
+
+    def test_creation_with_credentials(self) -> None:
+        client = AsyncUpbeat(access_key="test-key", secret_key="test-secret")
+        assert client._credentials is not None
+        assert isinstance(client._credentials, Credentials)
+
+    def test_creation_access_key_only_raises(self) -> None:
+        with pytest.raises(ValueError, match="Both access_key and secret_key"):
+            AsyncUpbeat(access_key="test-key")
+
+    def test_creation_secret_key_only_raises(self) -> None:
+        with pytest.raises(ValueError, match="Both access_key and secret_key"):
+            AsyncUpbeat(secret_key="test-secret")
+
+
+# ── TestAsyncUpbeatContextManager ────────────────────────────────────────
+
+
+class TestAsyncUpbeatContextManager:
+    @pytest.mark.asyncio
+    async def test_context_manager_closes(self) -> None:
+        async with AsyncUpbeat() as client:
+            assert client._closed is False
+        assert client._closed is True
+
+    @pytest.mark.asyncio
+    async def test_context_manager_external_client_not_closed(self) -> None:
+        http_client = httpx.AsyncClient(base_url=API_BASE_URL)
+        async with AsyncUpbeat(http_client=http_client) as client:
+            assert client._owns_http_client is False
+        assert not http_client.is_closed
+        await http_client.aclose()
+
+
+# ── TestAsyncUpbeatWithOptions ───────────────────────────────────────────
+
+
+class TestAsyncUpbeatWithOptions:
+    def test_shares_http_client(self) -> None:
+        client = AsyncUpbeat()
+        new = client.with_options(max_retries=10)
+        assert new._transport._client is client._transport._client
+        assert new._owns_http_client is False
+
+    def test_overrides_max_retries(self) -> None:
+        client = AsyncUpbeat(max_retries=3)
+        new = client.with_options(max_retries=10)
+        assert new._max_retries == 10
+
+    def test_preserves_credentials(self) -> None:
+        client = AsyncUpbeat(access_key="test-key", secret_key="test-secret")
+        new = client.with_options(max_retries=1)
+        assert new._credentials is client._credentials
+
+
+# ── TestAsyncUpbeatResources ─────────────────────────────────────────────
+
+
+class TestAsyncUpbeatResources:
+    def test_cached_property_returns_same_instance(self) -> None:
+        client = AsyncUpbeat()
+        q1 = client.quotation
+        q2 = client.quotation
+        assert q1 is q2
+
+    def test_resource_types(self) -> None:
+        client = AsyncUpbeat(access_key="test-key", secret_key="test-secret")
+        assert isinstance(client.quotation, AsyncQuotationAPI)
+        assert isinstance(client.accounts, AsyncAccountsAPI)
+        assert isinstance(client.orders, AsyncOrdersAPI)
+        assert isinstance(client.deposits, AsyncDepositsAPI)
+        assert isinstance(client.withdrawals, AsyncWithdrawalsAPI)
+        assert isinstance(client.markets, AsyncMarketsAPI)
+
+    def test_resources_receive_transport_and_credentials(self) -> None:
+        client = AsyncUpbeat(access_key="test-key", secret_key="test-secret")
+        resource = client.quotation
+        assert resource._transport is client._transport
+        assert resource._credentials is client._credentials


### PR DESCRIPTION
## 요약

- `src/upbeat/_client.py`에 `Upbeat`(동기) 및 `AsyncUpbeat`(비동기) 메인 클라이언트 클래스 추가
- API 리소스 베이스 클래스(`_SyncAPIResource`, `_AsyncAPIResource`) 및 스텁 서브 리소스(Quotation, Accounts, Orders, Deposits, Withdrawals, Markets) 구현
- 크레덴셜 검증, 라이프사이클 관리(`close`/`aclose`, 컨텍스트 매니저), httpx 클라이언트를 공유하는 `with_options()` 설정 오버라이드 지원
- `src/upbeat/__init__.py`에서 `Upbeat`, `AsyncUpbeat` export 추가
- 생성, 크레덴셜, close 멱등성, 컨텍스트 매니저, `with_options`, cached_property 리소스를 커버하는 29개 테스트 추가

## 테스트 계획

- [x] `uv run pytest tests/test_client.py -v` — 29개 테스트 통과
- [x] `uv run pytest` — 전체 176개 테스트 통과
- [x] `uv run pyright src/upbeat/_client.py` — 에러 0건

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)