### PR TITLE
feat: implement module-level convenience functions

### DIFF
--- a/src/upbeat/__init__.py
+++ b/src/upbeat/__init__.py
@@ -1,5 +1,14 @@
 from upbeat._client import AsyncUpbeat, Upbeat
 from upbeat._auth import Credentials
+from upbeat._convenience import (
+    get_candles,
+    get_markets,
+    get_orderbook,
+    get_orderbooks,
+    get_ticker,
+    get_tickers,
+    get_trades,
+)
 from upbeat.types.common import APIResponse
 from upbeat._config import DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT, Timeout, UpbeatConfig
 from upbeat._constants import (
@@ -76,6 +85,14 @@ __all__ = [
     "ResponseInfo",
     "RetryInfo",
     "WebSocketEventInfo",
+    # Convenience functions
+    "get_candles",
+    "get_markets",
+    "get_orderbook",
+    "get_orderbooks",
+    "get_ticker",
+    "get_tickers",
+    "get_trades",
     # Errors
     "APIConnectionError",
     "APIError",

--- a/src/upbeat/_convenience.py
+++ b/src/upbeat/_convenience.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from upbeat._client import Upbeat
+from upbeat.types.market import TradingPair
+from upbeat.types.quotation import (
+    CandleDay,
+    CandleMinute,
+    CandlePeriod,
+    CandleSecond,
+    Orderbook,
+    Ticker,
+    Trade,
+)
+
+_MINUTE_UNITS: dict[str, int] = {
+    "1m": 1, "3m": 3, "5m": 5, "10m": 10,
+    "15m": 15, "30m": 30, "60m": 60, "240m": 240,
+}
+
+
+def get_ticker(market: str) -> Ticker:
+    with Upbeat() as client:
+        return client.quotation.get_tickers(market)[0]
+
+
+def get_tickers(markets: str) -> list[Ticker]:
+    with Upbeat() as client:
+        return client.quotation.get_tickers(markets)
+
+
+def get_candles(
+    market: str,
+    *,
+    interval: str,
+    to: str | None = None,
+    count: int | None = None,
+) -> list[CandleMinute] | list[CandleSecond] | list[CandleDay] | list[CandlePeriod]:
+    with Upbeat() as client:
+        if interval in _MINUTE_UNITS:
+            return client.quotation.get_candles_minutes(
+                market=market, unit=_MINUTE_UNITS[interval], to=to, count=count,  # type: ignore[arg-type]
+            )
+        if interval == "1s":
+            return client.quotation.get_candles_seconds(
+                market=market, to=to, count=count,
+            )
+        if interval == "1d":
+            return client.quotation.get_candles_days(
+                market=market, to=to, count=count,
+            )
+        if interval == "1w":
+            return client.quotation.get_candles_weeks(
+                market=market, to=to, count=count,
+            )
+        if interval == "1M":
+            return client.quotation.get_candles_months(
+                market=market, to=to, count=count,
+            )
+        if interval == "1y":
+            return client.quotation.get_candles_years(
+                market=market, to=to, count=count,
+            )
+        raise ValueError(
+            f"Invalid interval: {interval!r}. "
+            f"Expected one of: 1s, 1m, 3m, 5m, 10m, 15m, 30m, 60m, 240m, 1d, 1w, 1M, 1y"
+        )
+
+
+def get_orderbook(market: str) -> Orderbook:
+    with Upbeat() as client:
+        return client.quotation.get_orderbooks(market)[0]
+
+
+def get_orderbooks(markets: str) -> list[Orderbook]:
+    with Upbeat() as client:
+        return client.quotation.get_orderbooks(markets)
+
+
+def get_trades(
+    market: str,
+    *,
+    to: str | None = None,
+    count: int | None = None,
+    cursor: str | None = None,
+    days_ago: int | None = None,
+) -> list[Trade]:
+    with Upbeat() as client:
+        return client.quotation.get_trades(
+            market, to=to, count=count, cursor=cursor, days_ago=days_ago,
+        )
+
+
+def get_markets(*, is_details: bool = False) -> list[TradingPair]:
+    with Upbeat() as client:
+        return client.markets.get_trading_pairs(is_details=is_details)

--- a/tests/test_convenience.py
+++ b/tests/test_convenience.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import upbeat
+from upbeat._convenience import (
+    get_candles,
+    get_markets,
+    get_orderbook,
+    get_orderbooks,
+    get_ticker,
+    get_tickers,
+    get_trades,
+)
+
+
+@pytest.fixture()
+def mock_client():
+    with patch("upbeat._convenience.Upbeat") as MockUpbeat:
+        client = MagicMock()
+        MockUpbeat.return_value.__enter__ = MagicMock(return_value=client)
+        MockUpbeat.return_value.__exit__ = MagicMock(return_value=False)
+        yield client
+
+
+class TestGetTicker:
+    def test_returns_first_element(self, mock_client: MagicMock) -> None:
+        sentinel = object()
+        mock_client.quotation.get_tickers.return_value = [sentinel]
+
+        result = get_ticker("KRW-BTC")
+
+        mock_client.quotation.get_tickers.assert_called_once_with("KRW-BTC")
+        assert result is sentinel
+
+
+class TestGetTickers:
+    def test_delegates_to_client(self, mock_client: MagicMock) -> None:
+        sentinel = [object(), object()]
+        mock_client.quotation.get_tickers.return_value = sentinel
+
+        result = get_tickers("KRW-BTC,KRW-ETH")
+
+        mock_client.quotation.get_tickers.assert_called_once_with("KRW-BTC,KRW-ETH")
+        assert result is sentinel
+
+
+class TestGetCandles:
+    @pytest.mark.parametrize(
+        ("interval", "expected_unit"),
+        [
+            ("1m", 1), ("3m", 3), ("5m", 5), ("10m", 10),
+            ("15m", 15), ("30m", 30), ("60m", 60), ("240m", 240),
+        ],
+    )
+    def test_minute_intervals(
+        self, mock_client: MagicMock, interval: str, expected_unit: int,
+    ) -> None:
+        sentinel = [object()]
+        mock_client.quotation.get_candles_minutes.return_value = sentinel
+
+        result = get_candles("KRW-BTC", interval=interval)
+
+        mock_client.quotation.get_candles_minutes.assert_called_once_with(
+            market="KRW-BTC", unit=expected_unit, to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_second_interval(self, mock_client: MagicMock) -> None:
+        sentinel = [object()]
+        mock_client.quotation.get_candles_seconds.return_value = sentinel
+
+        result = get_candles("KRW-BTC", interval="1s")
+
+        mock_client.quotation.get_candles_seconds.assert_called_once_with(
+            market="KRW-BTC", to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_day_interval(self, mock_client: MagicMock) -> None:
+        sentinel = [object()]
+        mock_client.quotation.get_candles_days.return_value = sentinel
+
+        result = get_candles("KRW-BTC", interval="1d")
+
+        mock_client.quotation.get_candles_days.assert_called_once_with(
+            market="KRW-BTC", to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_week_interval(self, mock_client: MagicMock) -> None:
+        sentinel = [object()]
+        mock_client.quotation.get_candles_weeks.return_value = sentinel
+
+        result = get_candles("KRW-BTC", interval="1w")
+
+        mock_client.quotation.get_candles_weeks.assert_called_once_with(
+            market="KRW-BTC", to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_month_interval(self, mock_client: MagicMock) -> None:
+        sentinel = [object()]
+        mock_client.quotation.get_candles_months.return_value = sentinel
+
+        result = get_candles("KRW-BTC", interval="1M")
+
+        mock_client.quotation.get_candles_months.assert_called_once_with(
+            market="KRW-BTC", to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_year_interval(self, mock_client: MagicMock) -> None:
+        sentinel = [object()]
+        mock_client.quotation.get_candles_years.return_value = sentinel
+
+        result = get_candles("KRW-BTC", interval="1y")
+
+        mock_client.quotation.get_candles_years.assert_called_once_with(
+            market="KRW-BTC", to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_optional_params_forwarded(self, mock_client: MagicMock) -> None:
+        mock_client.quotation.get_candles_minutes.return_value = []
+
+        get_candles("KRW-BTC", interval="5m", to="2024-01-01T00:00:00", count=10)
+
+        mock_client.quotation.get_candles_minutes.assert_called_once_with(
+            market="KRW-BTC", unit=5, to="2024-01-01T00:00:00", count=10,
+        )
+
+    def test_invalid_interval_raises_value_error(self) -> None:
+        with patch("upbeat._convenience.Upbeat"):
+            with pytest.raises(ValueError, match="Invalid interval"):
+                get_candles("KRW-BTC", interval="2h")
+
+
+class TestGetOrderbook:
+    def test_returns_first_element(self, mock_client: MagicMock) -> None:
+        sentinel = object()
+        mock_client.quotation.get_orderbooks.return_value = [sentinel]
+
+        result = get_orderbook("KRW-BTC")
+
+        mock_client.quotation.get_orderbooks.assert_called_once_with("KRW-BTC")
+        assert result is sentinel
+
+
+class TestGetOrderbooks:
+    def test_delegates_to_client(self, mock_client: MagicMock) -> None:
+        sentinel = [object(), object()]
+        mock_client.quotation.get_orderbooks.return_value = sentinel
+
+        result = get_orderbooks("KRW-BTC,KRW-ETH")
+
+        mock_client.quotation.get_orderbooks.assert_called_once_with("KRW-BTC,KRW-ETH")
+        assert result is sentinel
+
+
+class TestGetTrades:
+    def test_delegates_with_defaults(self, mock_client: MagicMock) -> None:
+        sentinel = [object()]
+        mock_client.quotation.get_trades.return_value = sentinel
+
+        result = get_trades("KRW-BTC")
+
+        mock_client.quotation.get_trades.assert_called_once_with(
+            "KRW-BTC", to=None, count=None, cursor=None, days_ago=None,
+        )
+        assert result is sentinel
+
+    def test_optional_params_forwarded(self, mock_client: MagicMock) -> None:
+        mock_client.quotation.get_trades.return_value = []
+
+        get_trades("KRW-BTC", to="12:00:00", count=5, cursor="abc", days_ago=1)
+
+        mock_client.quotation.get_trades.assert_called_once_with(
+            "KRW-BTC", to="12:00:00", count=5, cursor="abc", days_ago=1,
+        )
+
+
+class TestGetMarkets:
+    def test_delegates_with_default(self, mock_client: MagicMock) -> None:
+        sentinel = [object()]
+        mock_client.markets.get_trading_pairs.return_value = sentinel
+
+        result = get_markets()
+
+        mock_client.markets.get_trading_pairs.assert_called_once_with(is_details=False)
+        assert result is sentinel
+
+    def test_is_details_forwarded(self, mock_client: MagicMock) -> None:
+        mock_client.markets.get_trading_pairs.return_value = []
+
+        get_markets(is_details=True)
+
+        mock_client.markets.get_trading_pairs.assert_called_once_with(is_details=True)
+
+
+class TestModuleLevelAccess:
+    def test_functions_accessible_from_upbeat_module(self) -> None:
+        assert upbeat.get_ticker is get_ticker
+        assert upbeat.get_tickers is get_tickers
+        assert upbeat.get_candles is get_candles
+        assert upbeat.get_orderbook is get_orderbook
+        assert upbeat.get_orderbooks is get_orderbooks
+        assert upbeat.get_trades is get_trades
+        assert upbeat.get_markets is get_markets


### PR DESCRIPTION
## 요약
- `src/upbeat/_convenience.py`에 모듈 레벨 편의 함수 7개 구현 (`get_ticker`, `get_tickers`, `get_candles`, `get_orderbook`, `get_orderbooks`, `get_trades`, `get_markets`)
- 각 함수는 내부에서 `with Upbeat() as client:` 패턴으로 임시 클라이언트를 생성/정리하여 한 줄 호출 가능
- `get_candles`는 interval 문자열(`1s`, `1m`~`240m`, `1d`, `1w`, `1M`, `1y`)을 파싱하여 적절한 candle 메서드로 라우팅하며, 잘못된 interval에 대해 `ValueError` 발생
- `src/upbeat/__init__.py`에서 편의 함수를 export하여 `upbeat.get_ticker("KRW-BTC")` 형태로 사용 가능

## 테스트 계획
- [x] `tests/test_convenience.py` 24개 테스트 통과
- [x] 전체 회귀 테스트 228개 통과
- [x] Pyright LSP 진단 이상 없음

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)