### PR TITLE
feat: implement Exchange API (Accounts + Orders)

### DIFF
--- a/src/upbeat/_client.py
+++ b/src/upbeat/_client.py
@@ -11,19 +11,13 @@ from upbeat._config import DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT, Timeout
 from upbeat._constants import API_BASE_URL
 from upbeat._http import AsyncTransport, SyncTransport
 from upbeat._logger import Logger
+from upbeat.api.accounts import AccountsAPI, AsyncAccountsAPI
 from upbeat.api.markets import AsyncMarketsAPI, MarketsAPI
+from upbeat.api.orders import AsyncOrdersAPI, OrdersAPI
 from upbeat.api.quotation import AsyncQuotationAPI, QuotationAPI
 
 
 # ── Sync API resource stubs ─────────────────────────────────────────────
-
-
-class AccountsAPI(_SyncAPIResource):
-    pass
-
-
-class OrdersAPI(_SyncAPIResource):
-    pass
 
 
 class DepositsAPI(_SyncAPIResource):
@@ -35,14 +29,6 @@ class WithdrawalsAPI(_SyncAPIResource):
 
 
 # ── Async API resource stubs ────────────────────────────────────────────
-
-
-class AsyncAccountsAPI(_AsyncAPIResource):
-    pass
-
-
-class AsyncOrdersAPI(_AsyncAPIResource):
-    pass
 
 
 class AsyncDepositsAPI(_AsyncAPIResource):

--- a/src/upbeat/api/__init__.py
+++ b/src/upbeat/api/__init__.py
@@ -1,9 +1,15 @@
+from upbeat.api.accounts import AccountsAPI, AsyncAccountsAPI
 from upbeat.api.markets import AsyncMarketsAPI, MarketsAPI
+from upbeat.api.orders import AsyncOrdersAPI, OrdersAPI
 from upbeat.api.quotation import AsyncQuotationAPI, QuotationAPI
 
 __all__ = [
+    "AccountsAPI",
+    "AsyncAccountsAPI",
     "AsyncMarketsAPI",
+    "AsyncOrdersAPI",
     "AsyncQuotationAPI",
     "MarketsAPI",
+    "OrdersAPI",
     "QuotationAPI",
 ]

--- a/src/upbeat/api/accounts.py
+++ b/src/upbeat/api/accounts.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from upbeat._base import _AsyncAPIResource, _SyncAPIResource
+from upbeat.types.account import Account
+
+
+class AccountsAPI(_SyncAPIResource):
+    def list(self) -> list[Account]:
+        response = self._transport.request(
+            "GET", "/v1/accounts", credentials=self._credentials
+        )
+        return [Account.model_validate(item) for item in response.data]
+
+
+class AsyncAccountsAPI(_AsyncAPIResource):
+    async def list(self) -> list[Account]:
+        response = await self._transport.request(
+            "GET", "/v1/accounts", credentials=self._credentials
+        )
+        return [Account.model_validate(item) for item in response.data]

--- a/src/upbeat/api/orders.py
+++ b/src/upbeat/api/orders.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+from typing import Any
+
+from upbeat._base import _AsyncAPIResource, _SyncAPIResource
+from upbeat.types.order import (
+    CancelAndNewOrderResponse,
+    CancelResult,
+    OrderByIds,
+    OrderCanceled,
+    OrderChance,
+    OrderClosed,
+    OrderCreated,
+    OrderDetail,
+    OrderOpen,
+)
+
+
+def _filter_params(**kwargs: Any) -> dict[str, Any]:
+    return {k: v for k, v in kwargs.items() if v is not None}
+
+
+class OrdersAPI(_SyncAPIResource):
+    def create(
+        self,
+        *,
+        market: str,
+        side: str,
+        volume: str | None = None,
+        price: str | None = None,
+        ord_type: str = "limit",
+        identifier: str | None = None,
+        time_in_force: str | None = None,
+        smp_type: str | None = None,
+    ) -> OrderCreated:
+        json_body = _filter_params(
+            market=market,
+            side=side,
+            volume=volume,
+            price=price,
+            ord_type=ord_type,
+            identifier=identifier,
+            time_in_force=time_in_force,
+            smp_type=smp_type,
+        )
+        response = self._transport.request(
+            "POST", "/v1/orders", json_body=json_body, credentials=self._credentials
+        )
+        return OrderCreated.model_validate(response.data)
+
+    def create_test(
+        self,
+        *,
+        market: str,
+        side: str,
+        volume: str | None = None,
+        price: str | None = None,
+        ord_type: str = "limit",
+        identifier: str | None = None,
+        time_in_force: str | None = None,
+        smp_type: str | None = None,
+    ) -> OrderCreated:
+        json_body = _filter_params(
+            market=market,
+            side=side,
+            volume=volume,
+            price=price,
+            ord_type=ord_type,
+            identifier=identifier,
+            time_in_force=time_in_force,
+            smp_type=smp_type,
+        )
+        response = self._transport.request(
+            "POST",
+            "/v1/orders/test",
+            json_body=json_body,
+            credentials=self._credentials,
+        )
+        return OrderCreated.model_validate(response.data)
+
+    def get(
+        self,
+        *,
+        uuid: str | None = None,
+        identifier: str | None = None,
+    ) -> OrderDetail:
+        params = _filter_params(uuid=uuid, identifier=identifier)
+        response = self._transport.request(
+            "GET", "/v1/order", params=params, credentials=self._credentials
+        )
+        return OrderDetail.model_validate(response.data)
+
+    def cancel(
+        self,
+        *,
+        uuid: str | None = None,
+        identifier: str | None = None,
+    ) -> OrderCanceled:
+        params = _filter_params(uuid=uuid, identifier=identifier)
+        response = self._transport.request(
+            "DELETE", "/v1/order", params=params, credentials=self._credentials
+        )
+        return OrderCanceled.model_validate(response.data)
+
+    def list_open(
+        self,
+        *,
+        market: str | None = None,
+        state: str | None = None,
+        states: list[str] | None = None,
+        page: int | None = None,
+        limit: int | None = None,
+        order_by: str | None = None,
+    ) -> list[OrderOpen]:
+        params: dict[str, Any] = _filter_params(
+            market=market, state=state, page=page, limit=limit, order_by=order_by
+        )
+        if states is not None:
+            params["states[]"] = states
+        response = self._transport.request(
+            "GET", "/v1/orders/open", params=params, credentials=self._credentials
+        )
+        return [OrderOpen.model_validate(item) for item in response.data]
+
+    def cancel_open(
+        self,
+        *,
+        quote_currencies: str | None = None,
+        cancel_side: str | None = None,
+        count: int | None = None,
+        order_by: str | None = None,
+        pairs: str | None = None,
+        exclude_pairs: str | None = None,
+    ) -> CancelResult:
+        params = _filter_params(
+            quote_currencies=quote_currencies,
+            cancel_side=cancel_side,
+            count=count,
+            order_by=order_by,
+            pairs=pairs,
+            exclude_pairs=exclude_pairs,
+        )
+        response = self._transport.request(
+            "DELETE", "/v1/orders/open", params=params, credentials=self._credentials
+        )
+        return CancelResult.model_validate(response.data)
+
+    def list_closed(
+        self,
+        *,
+        market: str | None = None,
+        state: str | None = None,
+        states: list[str] | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        limit: int | None = None,
+        order_by: str | None = None,
+    ) -> list[OrderClosed]:
+        params: dict[str, Any] = _filter_params(
+            market=market,
+            state=state,
+            start_time=start_time,
+            end_time=end_time,
+            limit=limit,
+            order_by=order_by,
+        )
+        if states is not None:
+            params["states[]"] = states
+        response = self._transport.request(
+            "GET", "/v1/orders/closed", params=params, credentials=self._credentials
+        )
+        return [OrderClosed.model_validate(item) for item in response.data]
+
+    def list_by_ids(
+        self,
+        *,
+        market: str | None = None,
+        uuids: list[str] | None = None,
+        identifiers: list[str] | None = None,
+        order_by: str | None = None,
+    ) -> list[OrderByIds]:
+        params: dict[str, Any] = _filter_params(
+            market=market, order_by=order_by
+        )
+        if uuids is not None:
+            params["uuids[]"] = uuids
+        if identifiers is not None:
+            params["identifiers[]"] = identifiers
+        response = self._transport.request(
+            "GET", "/v1/orders/uuids", params=params, credentials=self._credentials
+        )
+        return [OrderByIds.model_validate(item) for item in response.data]
+
+    def cancel_by_ids(
+        self,
+        *,
+        uuids: list[str] | None = None,
+        identifiers: list[str] | None = None,
+    ) -> CancelResult:
+        params: dict[str, Any] = {}
+        if uuids is not None:
+            params["uuids[]"] = uuids
+        if identifiers is not None:
+            params["identifiers[]"] = identifiers
+        response = self._transport.request(
+            "DELETE", "/v1/orders/uuids", params=params, credentials=self._credentials
+        )
+        return CancelResult.model_validate(response.data)
+
+    def cancel_and_new(
+        self,
+        *,
+        new_ord_type: str,
+        prev_order_uuid: str | None = None,
+        prev_order_identifier: str | None = None,
+        new_volume: str | None = None,
+        new_price: str | None = None,
+        new_identifier: str | None = None,
+        new_time_in_force: str | None = None,
+        new_smp_type: str | None = None,
+    ) -> CancelAndNewOrderResponse:
+        json_body = _filter_params(
+            new_ord_type=new_ord_type,
+            prev_order_uuid=prev_order_uuid,
+            prev_order_identifier=prev_order_identifier,
+            new_volume=new_volume,
+            new_price=new_price,
+            new_identifier=new_identifier,
+            new_time_in_force=new_time_in_force,
+            new_smp_type=new_smp_type,
+        )
+        response = self._transport.request(
+            "POST",
+            "/v1/orders/cancel_and_new",
+            json_body=json_body,
+            credentials=self._credentials,
+        )
+        return CancelAndNewOrderResponse.model_validate(response.data)
+
+    def get_chance(self, *, market: str) -> OrderChance:
+        params = {"market": market}
+        response = self._transport.request(
+            "GET", "/v1/orders/chance", params=params, credentials=self._credentials
+        )
+        return OrderChance.model_validate(response.data)
+
+
+class AsyncOrdersAPI(_AsyncAPIResource):
+    async def create(
+        self,
+        *,
+        market: str,
+        side: str,
+        volume: str | None = None,
+        price: str | None = None,
+        ord_type: str = "limit",
+        identifier: str | None = None,
+        time_in_force: str | None = None,
+        smp_type: str | None = None,
+    ) -> OrderCreated:
+        json_body = _filter_params(
+            market=market,
+            side=side,
+            volume=volume,
+            price=price,
+            ord_type=ord_type,
+            identifier=identifier,
+            time_in_force=time_in_force,
+            smp_type=smp_type,
+        )
+        response = await self._transport.request(
+            "POST", "/v1/orders", json_body=json_body, credentials=self._credentials
+        )
+        return OrderCreated.model_validate(response.data)
+
+    async def create_test(
+        self,
+        *,
+        market: str,
+        side: str,
+        volume: str | None = None,
+        price: str | None = None,
+        ord_type: str = "limit",
+        identifier: str | None = None,
+        time_in_force: str | None = None,
+        smp_type: str | None = None,
+    ) -> OrderCreated:
+        json_body = _filter_params(
+            market=market,
+            side=side,
+            volume=volume,
+            price=price,
+            ord_type=ord_type,
+            identifier=identifier,
+            time_in_force=time_in_force,
+            smp_type=smp_type,
+        )
+        response = await self._transport.request(
+            "POST",
+            "/v1/orders/test",
+            json_body=json_body,
+            credentials=self._credentials,
+        )
+        return OrderCreated.model_validate(response.data)
+
+    async def get(
+        self,
+        *,
+        uuid: str | None = None,
+        identifier: str | None = None,
+    ) -> OrderDetail:
+        params = _filter_params(uuid=uuid, identifier=identifier)
+        response = await self._transport.request(
+            "GET", "/v1/order", params=params, credentials=self._credentials
+        )
+        return OrderDetail.model_validate(response.data)
+
+    async def cancel(
+        self,
+        *,
+        uuid: str | None = None,
+        identifier: str | None = None,
+    ) -> OrderCanceled:
+        params = _filter_params(uuid=uuid, identifier=identifier)
+        response = await self._transport.request(
+            "DELETE", "/v1/order", params=params, credentials=self._credentials
+        )
+        return OrderCanceled.model_validate(response.data)
+
+    async def list_open(
+        self,
+        *,
+        market: str | None = None,
+        state: str | None = None,
+        states: list[str] | None = None,
+        page: int | None = None,
+        limit: int | None = None,
+        order_by: str | None = None,
+    ) -> list[OrderOpen]:
+        params: dict[str, Any] = _filter_params(
+            market=market, state=state, page=page, limit=limit, order_by=order_by
+        )
+        if states is not None:
+            params["states[]"] = states
+        response = await self._transport.request(
+            "GET", "/v1/orders/open", params=params, credentials=self._credentials
+        )
+        return [OrderOpen.model_validate(item) for item in response.data]
+
+    async def cancel_open(
+        self,
+        *,
+        quote_currencies: str | None = None,
+        cancel_side: str | None = None,
+        count: int | None = None,
+        order_by: str | None = None,
+        pairs: str | None = None,
+        exclude_pairs: str | None = None,
+    ) -> CancelResult:
+        params = _filter_params(
+            quote_currencies=quote_currencies,
+            cancel_side=cancel_side,
+            count=count,
+            order_by=order_by,
+            pairs=pairs,
+            exclude_pairs=exclude_pairs,
+        )
+        response = await self._transport.request(
+            "DELETE", "/v1/orders/open", params=params, credentials=self._credentials
+        )
+        return CancelResult.model_validate(response.data)
+
+    async def list_closed(
+        self,
+        *,
+        market: str | None = None,
+        state: str | None = None,
+        states: list[str] | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        limit: int | None = None,
+        order_by: str | None = None,
+    ) -> list[OrderClosed]:
+        params: dict[str, Any] = _filter_params(
+            market=market,
+            state=state,
+            start_time=start_time,
+            end_time=end_time,
+            limit=limit,
+            order_by=order_by,
+        )
+        if states is not None:
+            params["states[]"] = states
+        response = await self._transport.request(
+            "GET", "/v1/orders/closed", params=params, credentials=self._credentials
+        )
+        return [OrderClosed.model_validate(item) for item in response.data]
+
+    async def list_by_ids(
+        self,
+        *,
+        market: str | None = None,
+        uuids: list[str] | None = None,
+        identifiers: list[str] | None = None,
+        order_by: str | None = None,
+    ) -> list[OrderByIds]:
+        params: dict[str, Any] = _filter_params(
+            market=market, order_by=order_by
+        )
+        if uuids is not None:
+            params["uuids[]"] = uuids
+        if identifiers is not None:
+            params["identifiers[]"] = identifiers
+        response = await self._transport.request(
+            "GET", "/v1/orders/uuids", params=params, credentials=self._credentials
+        )
+        return [OrderByIds.model_validate(item) for item in response.data]
+
+    async def cancel_by_ids(
+        self,
+        *,
+        uuids: list[str] | None = None,
+        identifiers: list[str] | None = None,
+    ) -> CancelResult:
+        params: dict[str, Any] = {}
+        if uuids is not None:
+            params["uuids[]"] = uuids
+        if identifiers is not None:
+            params["identifiers[]"] = identifiers
+        response = await self._transport.request(
+            "DELETE", "/v1/orders/uuids", params=params, credentials=self._credentials
+        )
+        return CancelResult.model_validate(response.data)
+
+    async def cancel_and_new(
+        self,
+        *,
+        new_ord_type: str,
+        prev_order_uuid: str | None = None,
+        prev_order_identifier: str | None = None,
+        new_volume: str | None = None,
+        new_price: str | None = None,
+        new_identifier: str | None = None,
+        new_time_in_force: str | None = None,
+        new_smp_type: str | None = None,
+    ) -> CancelAndNewOrderResponse:
+        json_body = _filter_params(
+            new_ord_type=new_ord_type,
+            prev_order_uuid=prev_order_uuid,
+            prev_order_identifier=prev_order_identifier,
+            new_volume=new_volume,
+            new_price=new_price,
+            new_identifier=new_identifier,
+            new_time_in_force=new_time_in_force,
+            new_smp_type=new_smp_type,
+        )
+        response = await self._transport.request(
+            "POST",
+            "/v1/orders/cancel_and_new",
+            json_body=json_body,
+            credentials=self._credentials,
+        )
+        return CancelAndNewOrderResponse.model_validate(response.data)
+
+    async def get_chance(self, *, market: str) -> OrderChance:
+        params = {"market": market}
+        response = await self._transport.request(
+            "GET", "/v1/orders/chance", params=params, credentials=self._credentials
+        )
+        return OrderChance.model_validate(response.data)

--- a/src/upbeat/types/__init__.py
+++ b/src/upbeat/types/__init__.py
@@ -1,5 +1,23 @@
+from upbeat.types.account import Account
 from upbeat.types.common import APIResponse
 from upbeat.types.market import MarketCaution, MarketEvent, TradingPair
+from upbeat.types.order import (
+    CancelAndNewOrderResponse,
+    CancelResult,
+    CancelResultGroup,
+    CancelResultOrder,
+    OrderByIds,
+    OrderCanceled,
+    OrderChance,
+    OrderChanceAccount,
+    OrderChanceMarket,
+    OrderChanceMarketBidAsk,
+    OrderClosed,
+    OrderCreated,
+    OrderDetail,
+    OrderOpen,
+    OrderTrade,
+)
 from upbeat.types.quotation import (
     CandleDay,
     CandleMinute,
@@ -14,6 +32,11 @@ from upbeat.types.quotation import (
 
 __all__ = [
     "APIResponse",
+    "Account",
+    "CancelAndNewOrderResponse",
+    "CancelResult",
+    "CancelResultGroup",
+    "CancelResultOrder",
     "CandleDay",
     "CandleMinute",
     "CandlePeriod",
@@ -23,6 +46,17 @@ __all__ = [
     "Orderbook",
     "OrderbookInstrument",
     "OrderbookUnit",
+    "OrderByIds",
+    "OrderCanceled",
+    "OrderChance",
+    "OrderChanceAccount",
+    "OrderChanceMarket",
+    "OrderChanceMarketBidAsk",
+    "OrderClosed",
+    "OrderCreated",
+    "OrderDetail",
+    "OrderOpen",
+    "OrderTrade",
     "Ticker",
     "Trade",
     "TradingPair",

--- a/src/upbeat/types/account.py
+++ b/src/upbeat/types/account.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Account(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    currency: str
+    balance: str
+    locked: str
+    avg_buy_price: str
+    avg_buy_price_modified: bool
+    unit_currency: str

--- a/src/upbeat/types/order.py
+++ b/src/upbeat/types/order.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+# ── OrderTrade (체결 내역, OrderDetail 내부) ────────────────────────────
+
+
+class OrderTrade(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    market: str
+    uuid: str
+    price: str
+    volume: str
+    funds: str
+    trend: str
+    created_at: str
+    side: str
+
+
+# ── OrderCreated (POST /v1/orders 응답) ─────────────────────────────────
+
+
+class OrderCreated(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    market: str
+    uuid: str
+    side: str
+    ord_type: str
+    price: str | None = None
+    state: str
+    created_at: str
+    volume: str | None = None
+    remaining_volume: str
+    executed_volume: str
+    reserved_fee: str
+    remaining_fee: str
+    paid_fee: str
+    locked: str
+    trades_count: int
+    time_in_force: str | None = None
+    identifier: str | None = None
+    smp_type: str | None = None
+    prevented_volume: str
+    prevented_locked: str
+
+
+# ── OrderDetail (GET /v1/order 응답) ────────────────────────────────────
+
+
+class OrderDetail(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    market: str
+    uuid: str
+    side: str
+    ord_type: str
+    price: str | None = None
+    state: str
+    created_at: str
+    volume: str | None = None
+    remaining_volume: str | None = None
+    executed_volume: str
+    reserved_fee: str
+    remaining_fee: str
+    paid_fee: str
+    locked: str
+    time_in_force: str | None = None
+    smp_type: str | None = None
+    prevented_volume: str | None = None
+    prevented_locked: str
+    identifier: str | None = None
+    trades_count: int
+    trades: list[OrderTrade]
+
+
+# ── OrderOpen (GET /v1/orders/open 응답) ────────────────────────────────
+
+
+class OrderOpen(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    market: str
+    uuid: str
+    side: str
+    ord_type: str
+    price: str | None = None
+    state: str
+    created_at: str
+    volume: str | None = None
+    remaining_volume: str
+    executed_volume: str
+    executed_funds: str
+    reserved_fee: str
+    remaining_fee: str
+    paid_fee: str
+    locked: str
+    time_in_force: str | None = None
+    identifier: str | None = None
+    smp_type: str | None = None
+    prevented_volume: str
+    prevented_locked: str
+    trades_count: int
+
+
+# ── OrderClosed (GET /v1/orders/closed 응답) ────────────────────────────
+
+
+class OrderClosed(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    market: str
+    uuid: str
+    side: str
+    ord_type: str
+    price: str
+    state: str
+    created_at: str
+    volume: str
+    remaining_volume: str
+    executed_volume: str
+    executed_funds: str
+    reserved_fee: str
+    remaining_fee: str
+    paid_fee: str
+    locked: str
+    time_in_force: str | None = None
+    identifier: str | None = None
+    smp_type: str | None = None
+    prevented_volume: str
+    prevented_locked: str
+    trades_count: int
+
+
+# ── OrderByIds (GET /v1/orders/uuids 응답) ──────────────────────────────
+
+
+class OrderByIds(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    market: str
+    uuid: str
+    side: str
+    ord_type: str
+    price: str | None = None
+    state: str
+    created_at: str
+    volume: str | None = None
+    remaining_volume: str | None = None
+    executed_volume: str
+    executed_funds: str
+    reserved_fee: str
+    remaining_fee: str
+    paid_fee: str
+    locked: str
+    time_in_force: str | None = None
+    identifier: str | None = None
+    smp_type: str | None = None
+    prevented_volume: str | None = None
+    prevented_locked: str
+    trades_count: int
+
+
+# ── OrderCanceled (DELETE /v1/order 응답) ───────────────────────────────
+
+
+class OrderCanceled(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    market: str
+    uuid: str
+    side: str
+    ord_type: str
+    price: str | None = None
+    state: str
+    created_at: str
+    volume: str | None = None
+    remaining_volume: str
+    executed_volume: str
+    reserved_fee: str
+    remaining_fee: str
+    paid_fee: str
+    locked: str
+    time_in_force: str | None = None
+    identifier: str | None = None
+    smp_type: str | None = None
+    prevented_volume: str
+    prevented_locked: str
+    trades_count: int
+
+
+# ── CancelResult (DELETE /v1/orders/open, /uuids 응답) ─────────────────
+
+
+class CancelResultOrder(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    uuid: str
+    market: str
+    identifier: str | None = None
+
+
+class CancelResultGroup(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    count: int
+    orders: list[CancelResultOrder]
+
+
+class CancelResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    success: CancelResultGroup
+    failed: CancelResultGroup
+
+
+# ── CancelAndNewOrderResponse (POST /v1/orders/cancel_and_new 응답) ─────
+
+
+class CancelAndNewOrderResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    market: str
+    uuid: str
+    identifier: str | None = None
+    side: str
+    ord_type: str
+    price: str | None = None
+    state: str
+    created_at: str
+    volume: str | None = None
+    remaining_volume: str
+    executed_volume: str
+    reserved_fee: str
+    remaining_fee: str
+    paid_fee: str
+    locked: str
+    prevented_volume: str
+    prevented_locked: str
+    smp_type: str | None = None
+    trades_count: int
+    time_in_force: str | None = None
+    new_order_uuid: str
+    new_order_identifier: str | None = None
+
+
+# ── OrderChance (GET /v1/orders/chance 응답) ────────────────────────────
+
+
+class OrderChanceMarketBidAsk(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    currency: str
+    min_total: str
+
+
+class OrderChanceMarket(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    name: str
+    order_types: list[str] | None = None
+    order_sides: list[str] | None = None
+    bid_types: list[str] | None = None
+    ask_types: list[str] | None = None
+    bid: OrderChanceMarketBidAsk | None = None
+    ask: OrderChanceMarketBidAsk | None = None
+    max_total: str | None = None
+    state: str | None = None
+
+
+class OrderChanceAccount(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    currency: str
+    balance: str
+    locked: str
+    avg_buy_price: str
+    avg_buy_price_modified: bool
+    unit_currency: str
+
+
+class OrderChance(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    bid_fee: str
+    ask_fee: str
+    maker_bid_fee: str
+    maker_ask_fee: str
+    market: OrderChanceMarket
+    bid_account: OrderChanceAccount
+    ask_account: OrderChanceAccount

--- a/tests/api/test_accounts.py
+++ b/tests/api/test_accounts.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from upbeat._auth import Credentials
+from upbeat._constants import API_BASE_URL
+from upbeat._http import AsyncTransport, SyncTransport
+from upbeat.api.accounts import AccountsAPI, AsyncAccountsAPI
+from upbeat.types.account import Account
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_transport(handler: Any, **kwargs: Any) -> SyncTransport:
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler), base_url=API_BASE_URL
+    )
+    return SyncTransport(http_client=client, **kwargs)
+
+
+def _make_async_transport(handler: Any, **kwargs: Any) -> AsyncTransport:
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url=API_BASE_URL
+    )
+    return AsyncTransport(http_client=client, **kwargs)
+
+
+def _json_response(data: Any, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=data)
+
+
+CREDENTIALS = Credentials(access_key="test-access-key", secret_key="test-secret-key")
+
+# ── Fixture data ─────────────────────────────────────────────────────────
+
+ACCOUNT_DATA = {
+    "currency": "KRW",
+    "balance": "1000000.0",
+    "locked": "0.0",
+    "avg_buy_price": "0",
+    "avg_buy_price_modified": False,
+    "unit_currency": "KRW",
+}
+
+ACCOUNT_BTC_DATA = {
+    "currency": "BTC",
+    "balance": "0.5",
+    "locked": "0.1",
+    "avg_buy_price": "50000000",
+    "avg_buy_price_modified": False,
+    "unit_currency": "KRW",
+}
+
+
+# ── TestListAccounts ─────────────────────────────────────────────────────
+
+
+class TestListAccounts:
+    def test_calls_correct_endpoint(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/accounts"
+            assert request.method == "GET"
+            return _json_response([ACCOUNT_DATA])
+
+        transport = _make_transport(handler)
+        api = AccountsAPI(transport, CREDENTIALS)
+        api.list()
+
+    def test_authorization_header_present(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert "Authorization" in request.headers
+            assert request.headers["Authorization"].startswith("Bearer ")
+            return _json_response([ACCOUNT_DATA])
+
+        transport = _make_transport(handler)
+        api = AccountsAPI(transport, CREDENTIALS)
+        api.list()
+
+    def test_parses_account_fields(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return _json_response([ACCOUNT_DATA])
+
+        transport = _make_transport(handler)
+        api = AccountsAPI(transport, CREDENTIALS)
+        result = api.list()
+        assert len(result) == 1
+        account = result[0]
+        assert isinstance(account, Account)
+        assert account.currency == "KRW"
+        assert account.balance == "1000000.0"
+        assert account.locked == "0.0"
+        assert account.avg_buy_price == "0"
+        assert account.avg_buy_price_modified is False
+        assert account.unit_currency == "KRW"
+
+    def test_returns_multiple_accounts(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return _json_response([ACCOUNT_DATA, ACCOUNT_BTC_DATA])
+
+        transport = _make_transport(handler)
+        api = AccountsAPI(transport, CREDENTIALS)
+        result = api.list()
+        assert len(result) == 2
+        assert result[0].currency == "KRW"
+        assert result[1].currency == "BTC"
+
+
+# ── TestAsyncListAccounts ────────────────────────────────────────────────
+
+
+class TestAsyncListAccounts:
+    @pytest.mark.asyncio
+    async def test_basic_call(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/accounts"
+            return _json_response([ACCOUNT_DATA])
+
+        transport = _make_async_transport(handler)
+        api = AsyncAccountsAPI(transport, CREDENTIALS)
+        result = await api.list()
+        assert len(result) == 1
+        assert isinstance(result[0], Account)
+
+    @pytest.mark.asyncio
+    async def test_authorization_header_present(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert "Authorization" in request.headers
+            assert request.headers["Authorization"].startswith("Bearer ")
+            return _json_response([ACCOUNT_DATA])
+
+        transport = _make_async_transport(handler)
+        api = AsyncAccountsAPI(transport, CREDENTIALS)
+        await api.list()

--- a/tests/api/test_orders.py
+++ b/tests/api/test_orders.py
@@ -1,0 +1,585 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from upbeat._auth import Credentials
+from upbeat._constants import API_BASE_URL
+from upbeat._http import AsyncTransport, SyncTransport
+from upbeat.api.orders import AsyncOrdersAPI, OrdersAPI
+from upbeat.types.order import (
+    CancelAndNewOrderResponse,
+    CancelResult,
+    OrderByIds,
+    OrderCanceled,
+    OrderChance,
+    OrderClosed,
+    OrderCreated,
+    OrderDetail,
+    OrderOpen,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_transport(handler: Any, **kwargs: Any) -> SyncTransport:
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler), base_url=API_BASE_URL
+    )
+    return SyncTransport(http_client=client, **kwargs)
+
+
+def _make_async_transport(handler: Any, **kwargs: Any) -> AsyncTransport:
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url=API_BASE_URL
+    )
+    return AsyncTransport(http_client=client, **kwargs)
+
+
+def _json_response(data: Any, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=data)
+
+
+CREDENTIALS = Credentials(access_key="test-access-key", secret_key="test-secret-key")
+
+
+# ── Shared fixture data ─────────────────────────────────────────────────
+
+ORDER_CREATED_DATA: dict[str, Any] = {
+    "market": "KRW-BTC",
+    "uuid": "uuid-1234",
+    "side": "bid",
+    "ord_type": "limit",
+    "price": "50000000",
+    "state": "wait",
+    "created_at": "2024-01-01T00:00:00+09:00",
+    "volume": "0.001",
+    "remaining_volume": "0.001",
+    "executed_volume": "0",
+    "reserved_fee": "25",
+    "remaining_fee": "25",
+    "paid_fee": "0",
+    "locked": "50025",
+    "trades_count": 0,
+    "prevented_volume": "0",
+    "prevented_locked": "0",
+}
+
+ORDER_DETAIL_DATA: dict[str, Any] = {
+    "market": "KRW-BTC",
+    "uuid": "uuid-1234",
+    "side": "bid",
+    "ord_type": "limit",
+    "price": "50000000",
+    "state": "done",
+    "created_at": "2024-01-01T00:00:00+09:00",
+    "volume": "0.001",
+    "remaining_volume": "0",
+    "executed_volume": "0.001",
+    "reserved_fee": "25",
+    "remaining_fee": "0",
+    "paid_fee": "25",
+    "locked": "0",
+    "prevented_locked": "0",
+    "trades_count": 1,
+    "trades": [
+        {
+            "market": "KRW-BTC",
+            "uuid": "trade-uuid-1",
+            "price": "50000000",
+            "volume": "0.001",
+            "funds": "50000",
+            "trend": "up",
+            "created_at": "2024-01-01T00:00:01.000+09:00",
+            "side": "bid",
+        }
+    ],
+}
+
+ORDER_OPEN_DATA: dict[str, Any] = {
+    "market": "KRW-BTC",
+    "uuid": "uuid-open-1",
+    "side": "bid",
+    "ord_type": "limit",
+    "price": "50000000",
+    "state": "wait",
+    "created_at": "2024-01-01T00:00:00+09:00",
+    "volume": "0.001",
+    "remaining_volume": "0.001",
+    "executed_volume": "0",
+    "executed_funds": "0",
+    "reserved_fee": "25",
+    "remaining_fee": "25",
+    "paid_fee": "0",
+    "locked": "50025",
+    "prevented_volume": "0",
+    "prevented_locked": "0",
+    "trades_count": 0,
+}
+
+ORDER_CLOSED_DATA: dict[str, Any] = {
+    "market": "KRW-BTC",
+    "uuid": "uuid-closed-1",
+    "side": "bid",
+    "ord_type": "limit",
+    "price": "50000000",
+    "state": "done",
+    "created_at": "2024-01-01T00:00:00+09:00",
+    "volume": "0.001",
+    "remaining_volume": "0",
+    "executed_volume": "0.001",
+    "executed_funds": "50000",
+    "reserved_fee": "25",
+    "remaining_fee": "0",
+    "paid_fee": "25",
+    "locked": "0",
+    "prevented_volume": "0",
+    "prevented_locked": "0",
+    "trades_count": 1,
+}
+
+ORDER_BY_IDS_DATA: dict[str, Any] = {
+    "market": "KRW-BTC",
+    "uuid": "uuid-byid-1",
+    "side": "bid",
+    "ord_type": "limit",
+    "price": "50000000",
+    "state": "wait",
+    "created_at": "2024-01-01T00:00:00+09:00",
+    "volume": "0.001",
+    "remaining_volume": "0.001",
+    "executed_volume": "0",
+    "executed_funds": "0",
+    "reserved_fee": "25",
+    "remaining_fee": "25",
+    "paid_fee": "0",
+    "locked": "50025",
+    "prevented_locked": "0",
+    "trades_count": 0,
+}
+
+ORDER_CANCELED_DATA: dict[str, Any] = {
+    "market": "KRW-BTC",
+    "uuid": "uuid-cancel-1",
+    "side": "bid",
+    "ord_type": "limit",
+    "price": "50000000",
+    "state": "wait",
+    "created_at": "2024-01-01T00:00:00+09:00",
+    "volume": "0.001",
+    "remaining_volume": "0.001",
+    "executed_volume": "0",
+    "reserved_fee": "25",
+    "remaining_fee": "25",
+    "paid_fee": "0",
+    "locked": "50025",
+    "prevented_volume": "0",
+    "prevented_locked": "0",
+    "trades_count": 0,
+}
+
+CANCEL_RESULT_DATA: dict[str, Any] = {
+    "success": {
+        "count": 1,
+        "orders": [{"uuid": "uuid-1", "market": "KRW-BTC"}],
+    },
+    "failed": {
+        "count": 0,
+        "orders": [],
+    },
+}
+
+CANCEL_AND_NEW_DATA: dict[str, Any] = {
+    "market": "KRW-BTC",
+    "uuid": "uuid-old",
+    "side": "bid",
+    "ord_type": "limit",
+    "price": "50000000",
+    "state": "wait",
+    "created_at": "2024-01-01T00:00:00+09:00",
+    "volume": "0.001",
+    "remaining_volume": "0.001",
+    "executed_volume": "0",
+    "reserved_fee": "25",
+    "remaining_fee": "25",
+    "paid_fee": "0",
+    "locked": "50025",
+    "prevented_volume": "0",
+    "prevented_locked": "0",
+    "trades_count": 0,
+    "new_order_uuid": "uuid-new",
+}
+
+ORDER_CHANCE_DATA: dict[str, Any] = {
+    "bid_fee": "0.0005",
+    "ask_fee": "0.0005",
+    "maker_bid_fee": "0.0005",
+    "maker_ask_fee": "0.0005",
+    "market": {
+        "id": "KRW-BTC",
+        "name": "BTC/KRW",
+        "order_types": ["limit"],
+        "order_sides": ["ask", "bid"],
+        "bid_types": ["limit", "price", "best"],
+        "ask_types": ["limit", "market", "best"],
+        "bid": {"currency": "KRW", "min_total": "5000"},
+        "ask": {"currency": "BTC", "min_total": "5000"},
+        "max_total": "1000000000",
+        "state": "active",
+    },
+    "bid_account": {
+        "currency": "KRW",
+        "balance": "1000000.0",
+        "locked": "0.0",
+        "avg_buy_price": "0",
+        "avg_buy_price_modified": False,
+        "unit_currency": "KRW",
+    },
+    "ask_account": {
+        "currency": "BTC",
+        "balance": "0.5",
+        "locked": "0.0",
+        "avg_buy_price": "50000000",
+        "avg_buy_price_modified": False,
+        "unit_currency": "KRW",
+    },
+}
+
+
+# ── TestCreateOrder ──────────────────────────────────────────────────────
+
+
+class TestCreateOrder:
+    def test_calls_correct_endpoint(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/orders"
+            assert request.method == "POST"
+            return _json_response(ORDER_CREATED_DATA, status_code=201)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        api.create(market="KRW-BTC", side="bid", price="50000000", volume="0.001")
+
+    def test_sends_json_body(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert body["market"] == "KRW-BTC"
+            assert body["side"] == "bid"
+            assert body["price"] == "50000000"
+            assert body["ord_type"] == "limit"
+            return _json_response(ORDER_CREATED_DATA, status_code=201)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        api.create(market="KRW-BTC", side="bid", price="50000000", volume="0.001")
+
+    def test_authorization_header_present(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert "Authorization" in request.headers
+            assert request.headers["Authorization"].startswith("Bearer ")
+            return _json_response(ORDER_CREATED_DATA, status_code=201)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        api.create(market="KRW-BTC", side="bid", price="50000000", volume="0.001")
+
+    def test_parses_response(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return _json_response(ORDER_CREATED_DATA, status_code=201)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.create(
+            market="KRW-BTC", side="bid", price="50000000", volume="0.001"
+        )
+        assert isinstance(result, OrderCreated)
+        assert result.market == "KRW-BTC"
+        assert result.uuid == "uuid-1234"
+        assert result.state == "wait"
+
+
+# ── TestCreateOrderTest ──────────────────────────────────────────────────
+
+
+class TestCreateOrderTest:
+    def test_calls_correct_endpoint(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/orders/test"
+            assert request.method == "POST"
+            return _json_response(ORDER_CREATED_DATA, status_code=201)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        api.create_test(market="KRW-BTC", side="bid", price="50000000", volume="0.001")
+
+
+# ── TestGetOrder ─────────────────────────────────────────────────────────
+
+
+class TestGetOrder:
+    def test_get_by_uuid(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/order"
+            assert request.url.params["uuid"] == "uuid-1234"
+            return _json_response(ORDER_DETAIL_DATA)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.get(uuid="uuid-1234")
+        assert isinstance(result, OrderDetail)
+        assert result.uuid == "uuid-1234"
+
+    def test_get_by_identifier(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.params["identifier"] == "my-id"
+            return _json_response(ORDER_DETAIL_DATA)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        api.get(identifier="my-id")
+
+    def test_parses_trades(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return _json_response(ORDER_DETAIL_DATA)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.get(uuid="uuid-1234")
+        assert len(result.trades) == 1
+        assert result.trades[0].trend == "up"
+        assert result.trades[0].funds == "50000"
+
+
+# ── TestCancelOrder ──────────────────────────────────────────────────────
+
+
+class TestCancelOrder:
+    def test_cancel_by_uuid(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/order"
+            assert request.method == "DELETE"
+            assert request.url.params["uuid"] == "uuid-cancel-1"
+            return _json_response(ORDER_CANCELED_DATA)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.cancel(uuid="uuid-cancel-1")
+        assert isinstance(result, OrderCanceled)
+        assert result.uuid == "uuid-cancel-1"
+
+
+# ── TestListOpenOrders ───────────────────────────────────────────────────
+
+
+class TestListOpenOrders:
+    def test_calls_correct_endpoint(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/orders/open"
+            assert request.method == "GET"
+            return _json_response([ORDER_OPEN_DATA])
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.list_open()
+        assert len(result) == 1
+        assert isinstance(result[0], OrderOpen)
+
+    def test_states_array_param(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            params = str(request.url)
+            assert "states%5B%5D=wait" in params or "states[]=wait" in params
+            assert "states%5B%5D=watch" in params or "states[]=watch" in params
+            return _json_response([ORDER_OPEN_DATA])
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        api.list_open(states=["wait", "watch"])
+
+
+# ── TestCancelOpenOrders ─────────────────────────────────────────────────
+
+
+class TestCancelOpenOrders:
+    def test_calls_correct_endpoint(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/orders/open"
+            assert request.method == "DELETE"
+            return _json_response(CANCEL_RESULT_DATA)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.cancel_open()
+        assert isinstance(result, CancelResult)
+        assert result.success.count == 1
+        assert result.failed.count == 0
+
+
+# ── TestListClosedOrders ─────────────────────────────────────────────────
+
+
+class TestListClosedOrders:
+    def test_calls_correct_endpoint(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/orders/closed"
+            return _json_response([ORDER_CLOSED_DATA])
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.list_closed()
+        assert len(result) == 1
+        assert isinstance(result[0], OrderClosed)
+        assert result[0].state == "done"
+
+    def test_states_and_time_params(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            params = str(request.url)
+            assert "states%5B%5D=done" in params or "states[]=done" in params
+            assert "start_time=" in params
+            return _json_response([ORDER_CLOSED_DATA])
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        api.list_closed(states=["done"], start_time="2024-01-01T00:00:00")
+
+
+# ── TestListOrdersByIds ──────────────────────────────────────────────────
+
+
+class TestListOrdersByIds:
+    def test_uuids_array_param(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/orders/uuids"
+            params = str(request.url)
+            assert "uuids%5B%5D=uuid-1" in params or "uuids[]=uuid-1" in params
+            return _json_response([ORDER_BY_IDS_DATA])
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.list_by_ids(uuids=["uuid-1", "uuid-2"])
+        assert len(result) == 1
+        assert isinstance(result[0], OrderByIds)
+
+
+# ── TestCancelOrdersByIds ────────────────────────────────────────────────
+
+
+class TestCancelOrdersByIds:
+    def test_calls_correct_endpoint(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/orders/uuids"
+            assert request.method == "DELETE"
+            return _json_response(CANCEL_RESULT_DATA)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.cancel_by_ids(uuids=["uuid-1"])
+        assert isinstance(result, CancelResult)
+
+
+# ── TestCancelAndNewOrder ────────────────────────────────────────────────
+
+
+class TestCancelAndNewOrder:
+    def test_calls_correct_endpoint(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/orders/cancel_and_new"
+            assert request.method == "POST"
+            body = json.loads(request.content)
+            assert body["prev_order_uuid"] == "uuid-old"
+            assert body["new_ord_type"] == "limit"
+            return _json_response(CANCEL_AND_NEW_DATA, status_code=201)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.cancel_and_new(
+            prev_order_uuid="uuid-old",
+            new_ord_type="limit",
+            new_price="51000000",
+            new_volume="0.001",
+        )
+        assert isinstance(result, CancelAndNewOrderResponse)
+        assert result.new_order_uuid == "uuid-new"
+
+
+# ── TestGetOrderChance ───────────────────────────────────────────────────
+
+
+class TestGetOrderChance:
+    def test_calls_correct_endpoint(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/orders/chance"
+            assert request.url.params["market"] == "KRW-BTC"
+            return _json_response(ORDER_CHANCE_DATA)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.get_chance(market="KRW-BTC")
+        assert isinstance(result, OrderChance)
+        assert result.bid_fee == "0.0005"
+
+    def test_parses_nested_objects(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return _json_response(ORDER_CHANCE_DATA)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS)
+        result = api.get_chance(market="KRW-BTC")
+        assert result.market.id == "KRW-BTC"
+        assert result.market.bid is not None
+        assert result.market.bid.currency == "KRW"
+        assert result.bid_account.currency == "KRW"
+        assert result.ask_account.currency == "BTC"
+
+
+# ── TestAsyncOrders ──────────────────────────────────────────────────────
+
+
+class TestAsyncOrders:
+    @pytest.mark.asyncio
+    async def test_create(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/orders"
+            assert request.method == "POST"
+            return _json_response(ORDER_CREATED_DATA, status_code=201)
+
+        transport = _make_async_transport(handler)
+        api = AsyncOrdersAPI(transport, CREDENTIALS)
+        result = await api.create(
+            market="KRW-BTC", side="bid", price="50000000", volume="0.001"
+        )
+        assert isinstance(result, OrderCreated)
+
+    @pytest.mark.asyncio
+    async def test_get(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return _json_response(ORDER_DETAIL_DATA)
+
+        transport = _make_async_transport(handler)
+        api = AsyncOrdersAPI(transport, CREDENTIALS)
+        result = await api.get(uuid="uuid-1234")
+        assert isinstance(result, OrderDetail)
+        assert len(result.trades) == 1
+
+    @pytest.mark.asyncio
+    async def test_list_open(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return _json_response([ORDER_OPEN_DATA])
+
+        transport = _make_async_transport(handler)
+        api = AsyncOrdersAPI(transport, CREDENTIALS)
+        result = await api.list_open()
+        assert len(result) == 1
+        assert isinstance(result[0], OrderOpen)
+
+    @pytest.mark.asyncio
+    async def test_get_chance(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return _json_response(ORDER_CHANCE_DATA)
+
+        transport = _make_async_transport(handler)
+        api = AsyncOrdersAPI(transport, CREDENTIALS)
+        result = await api.get_chance(market="KRW-BTC")
+        assert isinstance(result, OrderChance)


### PR DESCRIPTION
## 요약
- **Account API**: `AccountsAPI` / `AsyncAccountsAPI` — `list()` 메서드로 `GET /v1/accounts` 구현
- **Orders API**: `OrdersAPI` / `AsyncOrdersAPI` — 11개 엔드포인트 구현 (create, create_test, get, cancel, list_open, cancel_open, list_closed, list_by_ids, cancel_by_ids, cancel_and_new, get_chance)
- **Pydantic 타입 모델**: `Account`, `OrderCreated`, `OrderDetail`, `OrderOpen`, `OrderClosed`, `OrderByIds`, `OrderCanceled`, `CancelResult`, `CancelAndNewOrderResponse`, `OrderChance` 및 중첩 타입 추가
- `_client.py`의 stub 클래스를 실제 import로 교체 (Deposits/Withdrawals stub은 유지)
- `api/__init__.py`, `types/__init__.py` export 갱신

## 테스트
- [x] `uv run pytest tests/api/test_accounts.py tests/api/test_orders.py -v` — 29개 테스트 통과
- [x] `uv run pytest` — 전체 257개 테스트 통과, 회귀 없음
- [x] `uv run pyright` — 신규 파일 에러 0건

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)