### PR TITLE
feat: pandas DataFrame 통합 (OHLCV 캔들 변환)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ dependencies = [
     "websockets>=16.0",
 ]
 
+[project.optional-dependencies]
+pandas = [
+    "pandas>=2.0",
+]
+
 [build-system]
 requires = ["uv_build>=0.10.8,<0.11.0"]
 build-backend = "uv_build"
@@ -18,6 +23,7 @@ build-backend = "uv_build"
 [dependency-groups]
 dev = [
     "mypy>=1.19.1",
+    "pandas>=2.0",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "ruff>=0.15.5",

--- a/src/upbeat/__init__.py
+++ b/src/upbeat/__init__.py
@@ -2,6 +2,7 @@ from upbeat._client import AsyncUpbeat, Upbeat
 from upbeat._auth import Credentials
 from upbeat._convenience import (
     get_candles,
+    get_candles_df,
     get_markets,
     get_orderbook,
     get_orderbooks,
@@ -87,6 +88,7 @@ __all__ = [
     "WebSocketEventInfo",
     # Convenience functions
     "get_candles",
+    "get_candles_df",
     "get_markets",
     "get_orderbook",
     "get_orderbooks",

--- a/src/upbeat/_convenience.py
+++ b/src/upbeat/_convenience.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from upbeat._client import Upbeat
 from upbeat.types.market import TradingPair
 from upbeat.types.quotation import (
@@ -11,6 +13,9 @@ from upbeat.types.quotation import (
     Ticker,
     Trade,
 )
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 _MINUTE_UNITS: dict[str, int] = {
     "1m": 1, "3m": 3, "5m": 5, "10m": 10,
@@ -58,6 +63,44 @@ def get_candles(
             )
         if interval == "1y":
             return client.quotation.get_candles_years(
+                market=market, to=to, count=count,
+            )
+        raise ValueError(
+            f"Invalid interval: {interval!r}. "
+            f"Expected one of: 1s, 1m, 3m, 5m, 10m, 15m, 30m, 60m, 240m, 1d, 1w, 1M, 1y"
+        )
+
+
+def get_candles_df(
+    market: str,
+    *,
+    interval: str,
+    to: str | None = None,
+    count: int | None = None,
+) -> pd.DataFrame:
+    with Upbeat() as client:
+        if interval in _MINUTE_UNITS:
+            return client.quotation.get_candles_minutes_df(
+                market=market, unit=_MINUTE_UNITS[interval], to=to, count=count,  # type: ignore[arg-type]
+            )
+        if interval == "1s":
+            return client.quotation.get_candles_seconds_df(
+                market=market, to=to, count=count,
+            )
+        if interval == "1d":
+            return client.quotation.get_candles_days_df(
+                market=market, to=to, count=count,
+            )
+        if interval == "1w":
+            return client.quotation.get_candles_weeks_df(
+                market=market, to=to, count=count,
+            )
+        if interval == "1M":
+            return client.quotation.get_candles_months_df(
+                market=market, to=to, count=count,
+            )
+        if interval == "1y":
+            return client.quotation.get_candles_years_df(
                 market=market, to=to, count=count,
             )
         raise ValueError(

--- a/src/upbeat/_pandas.py
+++ b/src/upbeat/_pandas.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from upbeat.types.quotation import CandleBase
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+_COLUMNS = [
+    "market",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "timestamp",
+]
+
+
+def candles_to_dataframe(candles: Sequence[CandleBase]) -> pd.DataFrame:
+    try:
+        import pandas as pd
+    except ImportError:
+        raise ImportError(
+            "pandas is required for DataFrame support. "
+            "Install it with: pip install 'upbeat[pandas]'"
+        ) from None
+
+    if not candles:
+        df = pd.DataFrame(columns=_COLUMNS)
+        df.index = pd.DatetimeIndex([], name="datetime", tz="UTC")
+        return df
+
+    rows = [
+        {
+            "market": c.market,
+            "open": c.opening_price,
+            "high": c.high_price,
+            "low": c.low_price,
+            "close": c.trade_price,
+            "volume": c.candle_acc_trade_volume,
+            "timestamp": c.timestamp,
+        }
+        for c in candles
+    ]
+    df = pd.DataFrame(rows)
+    df.index = pd.DatetimeIndex(
+        pd.to_datetime([c.candle_date_time_utc for c in candles], utc=True),
+        name="datetime",
+    )
+    return df

--- a/src/upbeat/api/quotation.py
+++ b/src/upbeat/api/quotation.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from upbeat._base import _AsyncAPIResource, _SyncAPIResource
+from upbeat._pandas import candles_to_dataframe
 from upbeat.types.quotation import (
     CandleDay,
     CandleMinute,
@@ -13,6 +14,9 @@ from upbeat.types.quotation import (
     Ticker,
     Trade,
 )
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def _filter_params(**kwargs: Any) -> dict[str, Any]:
@@ -102,6 +106,77 @@ class QuotationAPI(_SyncAPIResource):
         params = _filter_params(market=market, to=to, count=count)
         response = self._transport.request("GET", "/v1/candles/years", params=params)
         return [CandlePeriod.model_validate(item) for item in response.data]
+
+    def get_candles_minutes_df(
+        self,
+        *,
+        market: str,
+        unit: Literal[1, 3, 5, 10, 15, 30, 60, 240],
+        to: str | None = None,
+        count: int | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            self.get_candles_minutes(market=market, unit=unit, to=to, count=count)
+        )
+
+    def get_candles_seconds_df(
+        self,
+        *,
+        market: str,
+        to: str | None = None,
+        count: int | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            self.get_candles_seconds(market=market, to=to, count=count)
+        )
+
+    def get_candles_days_df(
+        self,
+        *,
+        market: str,
+        to: str | None = None,
+        count: int | None = None,
+        converting_price_unit: str | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            self.get_candles_days(
+                market=market, to=to, count=count,
+                converting_price_unit=converting_price_unit,
+            )
+        )
+
+    def get_candles_weeks_df(
+        self,
+        *,
+        market: str,
+        to: str | None = None,
+        count: int | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            self.get_candles_weeks(market=market, to=to, count=count)
+        )
+
+    def get_candles_months_df(
+        self,
+        *,
+        market: str,
+        to: str | None = None,
+        count: int | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            self.get_candles_months(market=market, to=to, count=count)
+        )
+
+    def get_candles_years_df(
+        self,
+        *,
+        market: str,
+        to: str | None = None,
+        count: int | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            self.get_candles_years(market=market, to=to, count=count)
+        )
 
     def get_orderbooks(
         self,
@@ -232,6 +307,79 @@ class AsyncQuotationAPI(_AsyncAPIResource):
             "GET", "/v1/candles/years", params=params
         )
         return [CandlePeriod.model_validate(item) for item in response.data]
+
+    async def get_candles_minutes_df(
+        self,
+        *,
+        market: str,
+        unit: Literal[1, 3, 5, 10, 15, 30, 60, 240],
+        to: str | None = None,
+        count: int | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            await self.get_candles_minutes(
+                market=market, unit=unit, to=to, count=count,
+            )
+        )
+
+    async def get_candles_seconds_df(
+        self,
+        *,
+        market: str,
+        to: str | None = None,
+        count: int | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            await self.get_candles_seconds(market=market, to=to, count=count)
+        )
+
+    async def get_candles_days_df(
+        self,
+        *,
+        market: str,
+        to: str | None = None,
+        count: int | None = None,
+        converting_price_unit: str | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            await self.get_candles_days(
+                market=market, to=to, count=count,
+                converting_price_unit=converting_price_unit,
+            )
+        )
+
+    async def get_candles_weeks_df(
+        self,
+        *,
+        market: str,
+        to: str | None = None,
+        count: int | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            await self.get_candles_weeks(market=market, to=to, count=count)
+        )
+
+    async def get_candles_months_df(
+        self,
+        *,
+        market: str,
+        to: str | None = None,
+        count: int | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            await self.get_candles_months(market=market, to=to, count=count)
+        )
+
+    async def get_candles_years_df(
+        self,
+        *,
+        market: str,
+        to: str | None = None,
+        count: int | None = None,
+    ) -> pd.DataFrame:
+        return candles_to_dataframe(
+            await self.get_candles_years(market=market, to=to, count=count)
+        )
 
     async def get_orderbooks(
         self,

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import builtins
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from upbeat._convenience import get_candles_df
+from upbeat._pandas import candles_to_dataframe
+from upbeat.types.quotation import (
+    CandleDay,
+    CandleMinute,
+    CandlePeriod,
+    CandleSecond,
+)
+
+_CANDLE_BASE_FIELDS = {
+    "market": "KRW-BTC",
+    "candle_date_time_utc": "2024-01-15T09:00:00",
+    "candle_date_time_kst": "2024-01-15T18:00:00",
+    "opening_price": 60000000.0,
+    "high_price": 61000000.0,
+    "low_price": 59000000.0,
+    "trade_price": 60500000.0,
+    "timestamp": 1705305600000,
+    "candle_acc_trade_price": 1000000000.0,
+    "candle_acc_trade_volume": 16.5,
+}
+
+
+class TestCandlesToDataFrame:
+    def test_returns_dataframe(self) -> None:
+        candle = CandleMinute(**_CANDLE_BASE_FIELDS, unit=1)
+        result = candles_to_dataframe([candle])
+        assert isinstance(result, pd.DataFrame)
+
+    def test_ohlcv_columns(self) -> None:
+        candle = CandleMinute(**_CANDLE_BASE_FIELDS, unit=1)
+        df = candles_to_dataframe([candle])
+
+        assert df["open"].iloc[0] == 60000000.0
+        assert df["high"].iloc[0] == 61000000.0
+        assert df["low"].iloc[0] == 59000000.0
+        assert df["close"].iloc[0] == 60500000.0
+        assert df["volume"].iloc[0] == 16.5
+        assert df["timestamp"].iloc[0] == 1705305600000
+
+    def test_market_column(self) -> None:
+        candle = CandleMinute(**_CANDLE_BASE_FIELDS, unit=1)
+        df = candles_to_dataframe([candle])
+        assert df["market"].iloc[0] == "KRW-BTC"
+
+    def test_datetime_index(self) -> None:
+        candle = CandleMinute(**_CANDLE_BASE_FIELDS, unit=1)
+        df = candles_to_dataframe([candle])
+
+        assert isinstance(df.index, pd.DatetimeIndex)
+        assert df.index.name == "datetime"
+        assert str(df.index.tz) == "UTC"
+
+    def test_empty_list(self) -> None:
+        df = candles_to_dataframe([])
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 0
+        assert "open" in df.columns
+        assert "high" in df.columns
+        assert "low" in df.columns
+        assert "close" in df.columns
+        assert "volume" in df.columns
+        assert isinstance(df.index, pd.DatetimeIndex)
+        assert df.index.name == "datetime"
+
+    def test_multiple_candles(self) -> None:
+        c1 = CandleMinute(
+            **{**_CANDLE_BASE_FIELDS, "candle_date_time_utc": "2024-01-15T09:00:00"},
+            unit=1,
+        )
+        c2 = CandleMinute(
+            **{**_CANDLE_BASE_FIELDS, "candle_date_time_utc": "2024-01-15T09:01:00"},
+            unit=1,
+        )
+        df = candles_to_dataframe([c1, c2])
+        assert len(df) == 2
+
+    def test_candle_second(self) -> None:
+        candle = CandleSecond(**_CANDLE_BASE_FIELDS)
+        df = candles_to_dataframe([candle])
+        assert len(df) == 1
+        assert df["close"].iloc[0] == 60500000.0
+
+    def test_candle_day(self) -> None:
+        candle = CandleDay(
+            **_CANDLE_BASE_FIELDS,
+            prev_closing_price=59500000.0,
+            change_price=1000000.0,
+            change_rate=0.0168,
+        )
+        df = candles_to_dataframe([candle])
+        assert len(df) == 1
+        assert df["close"].iloc[0] == 60500000.0
+
+    def test_candle_period(self) -> None:
+        candle = CandlePeriod(
+            **_CANDLE_BASE_FIELDS,
+            first_day_of_period="2024-01-15",
+        )
+        df = candles_to_dataframe([candle])
+        assert len(df) == 1
+        assert df["close"].iloc[0] == 60500000.0
+
+
+class TestImportError:
+    def test_missing_pandas_raises_import_error(self) -> None:
+        real_import = builtins.__import__
+
+        def mock_import(name: str, *args, **kwargs):
+            if name == "pandas":
+                raise ImportError
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=mock_import):
+            candle = CandleMinute(**_CANDLE_BASE_FIELDS, unit=1)
+            with pytest.raises(ImportError, match="upbeat\\[pandas\\]"):
+                candles_to_dataframe([candle])
+
+
+@pytest.fixture()
+def mock_client():
+    with patch("upbeat._convenience.Upbeat") as MockUpbeat:
+        client = MagicMock()
+        MockUpbeat.return_value.__enter__ = MagicMock(return_value=client)
+        MockUpbeat.return_value.__exit__ = MagicMock(return_value=False)
+        yield client
+
+
+class TestGetCandlesDf:
+    @pytest.mark.parametrize(
+        ("interval", "expected_unit"),
+        [
+            ("1m", 1), ("3m", 3), ("5m", 5), ("10m", 10),
+            ("15m", 15), ("30m", 30), ("60m", 60), ("240m", 240),
+        ],
+    )
+    def test_minute_intervals(
+        self, mock_client: MagicMock, interval: str, expected_unit: int,
+    ) -> None:
+        sentinel = MagicMock()
+        mock_client.quotation.get_candles_minutes_df.return_value = sentinel
+
+        result = get_candles_df("KRW-BTC", interval=interval)
+
+        mock_client.quotation.get_candles_minutes_df.assert_called_once_with(
+            market="KRW-BTC", unit=expected_unit, to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_second_interval(self, mock_client: MagicMock) -> None:
+        sentinel = MagicMock()
+        mock_client.quotation.get_candles_seconds_df.return_value = sentinel
+
+        result = get_candles_df("KRW-BTC", interval="1s")
+
+        mock_client.quotation.get_candles_seconds_df.assert_called_once_with(
+            market="KRW-BTC", to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_day_interval(self, mock_client: MagicMock) -> None:
+        sentinel = MagicMock()
+        mock_client.quotation.get_candles_days_df.return_value = sentinel
+
+        result = get_candles_df("KRW-BTC", interval="1d")
+
+        mock_client.quotation.get_candles_days_df.assert_called_once_with(
+            market="KRW-BTC", to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_week_interval(self, mock_client: MagicMock) -> None:
+        sentinel = MagicMock()
+        mock_client.quotation.get_candles_weeks_df.return_value = sentinel
+
+        result = get_candles_df("KRW-BTC", interval="1w")
+
+        mock_client.quotation.get_candles_weeks_df.assert_called_once_with(
+            market="KRW-BTC", to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_month_interval(self, mock_client: MagicMock) -> None:
+        sentinel = MagicMock()
+        mock_client.quotation.get_candles_months_df.return_value = sentinel
+
+        result = get_candles_df("KRW-BTC", interval="1M")
+
+        mock_client.quotation.get_candles_months_df.assert_called_once_with(
+            market="KRW-BTC", to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_year_interval(self, mock_client: MagicMock) -> None:
+        sentinel = MagicMock()
+        mock_client.quotation.get_candles_years_df.return_value = sentinel
+
+        result = get_candles_df("KRW-BTC", interval="1y")
+
+        mock_client.quotation.get_candles_years_df.assert_called_once_with(
+            market="KRW-BTC", to=None, count=None,
+        )
+        assert result is sentinel
+
+    def test_invalid_interval_raises_value_error(self) -> None:
+        with patch("upbeat._convenience.Upbeat"), pytest.raises(
+            ValueError, match="Invalid interval"
+        ):
+            get_candles_df("KRW-BTC", interval="2h")

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,14 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -180,12 +188,106 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", size = 20723651, upload-time = "2026-01-31T23:13:10.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/22/815b9fe25d1d7ae7d492152adbc7226d3eff731dffc38fe970589fcaaa38/numpy-2.4.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:25f2059807faea4b077a2b6837391b5d830864b3543627f381821c646f31a63c", size = 16663696, upload-time = "2026-01-31T23:11:17.516Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f0/817d03a03f93ba9c6c8993de509277d84e69f9453601915e4a69554102a1/numpy-2.4.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bd3a7a9f5847d2fb8c2c6d1c862fa109c31a9abeca1a3c2bd5a64572955b2979", size = 14688322, upload-time = "2026-01-31T23:11:19.883Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b4/f805ab79293c728b9a99438775ce51885fd4f31b76178767cfc718701a39/numpy-2.4.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8e4549f8a3c6d13d55041925e912bfd834285ef1dd64d6bc7d542583355e2e98", size = 5198157, upload-time = "2026-01-31T23:11:22.375Z" },
+    { url = "https://files.pythonhosted.org/packages/74/09/826e4289844eccdcd64aac27d13b0fd3f32039915dd5b9ba01baae1f436c/numpy-2.4.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:aea4f66ff44dfddf8c2cffd66ba6538c5ec67d389285292fe428cb2c738c8aef", size = 6546330, upload-time = "2026-01-31T23:11:23.958Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fb/cbfdbfa3057a10aea5422c558ac57538e6acc87ec1669e666d32ac198da7/numpy-2.4.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3cd545784805de05aafe1dde61752ea49a359ccba9760c1e5d1c88a93bbf2b7", size = 15660968, upload-time = "2026-01-31T23:11:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/04/dc/46066ce18d01645541f0186877377b9371b8fa8017fa8262002b4ef22612/numpy-2.4.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0d9b7c93578baafcbc5f0b83eaf17b79d345c6f36917ba0c67f45226911d499", size = 16607311, upload-time = "2026-01-31T23:11:28.117Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d9/4b5adfc39a43fa6bf918c6d544bc60c05236cc2f6339847fc5b35e6cb5b0/numpy-2.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f74f0f7779cc7ae07d1810aab8ac6b1464c3eafb9e283a40da7309d5e6e48fbb", size = 17012850, upload-time = "2026-01-31T23:11:30.888Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/20/adb6e6adde6d0130046e6fdfb7675cc62bc2f6b7b02239a09eb58435753d/numpy-2.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7ac672d699bf36275c035e16b65539931347d68b70667d28984c9fb34e07fa7", size = 18334210, upload-time = "2026-01-31T23:11:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0e/0a73b3dff26803a8c02baa76398015ea2a5434d9b8265a7898a6028c1591/numpy-2.4.2-cp313-cp313-win32.whl", hash = "sha256:8e9afaeb0beff068b4d9cd20d322ba0ee1cecfb0b08db145e4ab4dd44a6b5110", size = 5958199, upload-time = "2026-01-31T23:11:35.385Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bc/6352f343522fcb2c04dbaf94cb30cca6fd32c1a750c06ad6231b4293708c/numpy-2.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:7df2de1e4fba69a51c06c28f5a3de36731eb9639feb8e1cf7e4a7b0daf4cf622", size = 12310848, upload-time = "2026-01-31T23:11:38.001Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8d/6da186483e308da5da1cc6918ce913dcfe14ffde98e710bfeff2a6158d4e/numpy-2.4.2-cp313-cp313-win_arm64.whl", hash = "sha256:0fece1d1f0a89c16b03442eae5c56dc0be0c7883b5d388e0c03f53019a4bfd71", size = 10221082, upload-time = "2026-01-31T23:11:40.392Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a1/9510aa43555b44781968935c7548a8926274f815de42ad3997e9e83680dd/numpy-2.4.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5633c0da313330fd20c484c78cdd3f9b175b55e1a766c4a174230c6b70ad8262", size = 14815866, upload-time = "2026-01-31T23:11:42.495Z" },
+    { url = "https://files.pythonhosted.org/packages/36/30/6bbb5e76631a5ae46e7923dd16ca9d3f1c93cfa8d4ed79a129814a9d8db3/numpy-2.4.2-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d9f64d786b3b1dd742c946c42d15b07497ed14af1a1f3ce840cce27daa0ce913", size = 5325631, upload-time = "2026-01-31T23:11:44.7Z" },
+    { url = "https://files.pythonhosted.org/packages/46/00/3a490938800c1923b567b3a15cd17896e68052e2145d8662aaf3e1ffc58f/numpy-2.4.2-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:b21041e8cb6a1eb5312dd1d2f80a94d91efffb7a06b70597d44f1bd2dfc315ab", size = 6646254, upload-time = "2026-01-31T23:11:46.341Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/e9/fac0890149898a9b609caa5af7455a948b544746e4b8fe7c212c8edd71f8/numpy-2.4.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:00ab83c56211a1d7c07c25e3217ea6695e50a3e2f255053686b081dc0b091a82", size = 15720138, upload-time = "2026-01-31T23:11:48.082Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/5c/08887c54e68e1e28df53709f1893ce92932cc6f01f7c3d4dc952f61ffd4e/numpy-2.4.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fb882da679409066b4603579619341c6d6898fc83a8995199d5249f986e8e8f", size = 16655398, upload-time = "2026-01-31T23:11:50.293Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/89/253db0fa0e66e9129c745e4ef25631dc37d5f1314dad2b53e907b8538e6d/numpy-2.4.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:66cb9422236317f9d44b67b4d18f44efe6e9c7f8794ac0462978513359461554", size = 17079064, upload-time = "2026-01-31T23:11:52.927Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/d5/cbade46ce97c59c6c3da525e8d95b7abe8a42974a1dc5c1d489c10433e88/numpy-2.4.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0f01dcf33e73d80bd8dc0f20a71303abbafa26a19e23f6b68d1aa9990af90257", size = 18379680, upload-time = "2026-01-31T23:11:55.22Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/48f99ae172a4b63d981babe683685030e8a3df4f246c893ea5c6ef99f018/numpy-2.4.2-cp313-cp313t-win32.whl", hash = "sha256:52b913ec40ff7ae845687b0b34d8d93b60cb66dcee06996dd5c99f2fc9328657", size = 6082433, upload-time = "2026-01-31T23:11:58.096Z" },
+    { url = "https://files.pythonhosted.org/packages/07/38/e054a61cfe48ad9f1ed0d188e78b7e26859d0b60ef21cd9de4897cdb5326/numpy-2.4.2-cp313-cp313t-win_amd64.whl", hash = "sha256:5eea80d908b2c1f91486eb95b3fb6fab187e569ec9752ab7d9333d2e66bf2d6b", size = 12451181, upload-time = "2026-01-31T23:11:59.782Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a4/a05c3a6418575e185dd84d0b9680b6bb2e2dc3e4202f036b7b4e22d6e9dc/numpy-2.4.2-cp313-cp313t-win_arm64.whl", hash = "sha256:fd49860271d52127d61197bb50b64f58454e9f578cb4b2c001a6de8b1f50b0b1", size = 10290756, upload-time = "2026-01-31T23:12:02.438Z" },
+    { url = "https://files.pythonhosted.org/packages/18/88/b7df6050bf18fdcfb7046286c6535cabbdd2064a3440fca3f069d319c16e/numpy-2.4.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:444be170853f1f9d528428eceb55f12918e4fda5d8805480f36a002f1415e09b", size = 16663092, upload-time = "2026-01-31T23:12:04.521Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/1fee4329abc705a469a4afe6e69b1ef7e915117747886327104a8493a955/numpy-2.4.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d1240d50adff70c2a88217698ca844723068533f3f5c5fa6ee2e3220e3bdb000", size = 14698770, upload-time = "2026-01-31T23:12:06.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/0b/f9e49ba6c923678ad5bc38181c08ac5e53b7a5754dbca8e581aa1a56b1ff/numpy-2.4.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:7cdde6de52fb6664b00b056341265441192d1291c130e99183ec0d4b110ff8b1", size = 5208562, upload-time = "2026-01-31T23:12:09.632Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/12/d7de8f6f53f9bb76997e5e4c069eda2051e3fe134e9181671c4391677bb2/numpy-2.4.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:cda077c2e5b780200b6b3e09d0b42205a3d1c68f30c6dceb90401c13bff8fe74", size = 6543710, upload-time = "2026-01-31T23:12:11.969Z" },
+    { url = "https://files.pythonhosted.org/packages/09/63/c66418c2e0268a31a4cf8a8b512685748200f8e8e8ec6c507ce14e773529/numpy-2.4.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d30291931c915b2ab5717c2974bb95ee891a1cf22ebc16a8006bd59cd210d40a", size = 15677205, upload-time = "2026-01-31T23:12:14.33Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6c/7f237821c9642fb2a04d2f1e88b4295677144ca93285fd76eff3bcba858d/numpy-2.4.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bba37bc29d4d85761deed3954a1bc62be7cf462b9510b51d367b769a8c8df325", size = 16611738, upload-time = "2026-01-31T23:12:16.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a7/39c4cdda9f019b609b5c473899d87abff092fc908cfe4d1ecb2fcff453b0/numpy-2.4.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b2f0073ed0868db1dcd86e052d37279eef185b9c8db5bf61f30f46adac63c909", size = 17028888, upload-time = "2026-01-31T23:12:19.306Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b3/e84bb64bdfea967cc10950d71090ec2d84b49bc691df0025dddb7c26e8e3/numpy-2.4.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7f54844851cdb630ceb623dcec4db3240d1ac13d4990532446761baede94996a", size = 18339556, upload-time = "2026-01-31T23:12:21.816Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f5/954a291bc1192a27081706862ac62bb5920fbecfbaa302f64682aa90beed/numpy-2.4.2-cp314-cp314-win32.whl", hash = "sha256:12e26134a0331d8dbd9351620f037ec470b7c75929cb8a1537f6bfe411152a1a", size = 6006899, upload-time = "2026-01-31T23:12:24.14Z" },
+    { url = "https://files.pythonhosted.org/packages/05/cb/eff72a91b2efdd1bc98b3b8759f6a1654aa87612fc86e3d87d6fe4f948c4/numpy-2.4.2-cp314-cp314-win_amd64.whl", hash = "sha256:068cdb2d0d644cdb45670810894f6a0600797a69c05f1ac478e8d31670b8ee75", size = 12443072, upload-time = "2026-01-31T23:12:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/37/75/62726948db36a56428fce4ba80a115716dc4fad6a3a4352487f8bb950966/numpy-2.4.2-cp314-cp314-win_arm64.whl", hash = "sha256:6ed0be1ee58eef41231a5c943d7d1375f093142702d5723ca2eb07db9b934b05", size = 10494886, upload-time = "2026-01-31T23:12:28.488Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2f/ee93744f1e0661dc267e4b21940870cabfae187c092e1433b77b09b50ac4/numpy-2.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:98f16a80e917003a12c0580f97b5f875853ebc33e2eaa4bccfc8201ac6869308", size = 14818567, upload-time = "2026-01-31T23:12:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/24/6535212add7d76ff938d8bdc654f53f88d35cddedf807a599e180dcb8e66/numpy-2.4.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:20abd069b9cda45874498b245c8015b18ace6de8546bf50dfa8cea1696ed06ef", size = 5328372, upload-time = "2026-01-31T23:12:32.962Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/9d/c48f0a035725f925634bf6b8994253b43f2047f6778a54147d7e213bc5a7/numpy-2.4.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:e98c97502435b53741540a5717a6749ac2ada901056c7db951d33e11c885cc7d", size = 6649306, upload-time = "2026-01-31T23:12:34.797Z" },
+    { url = "https://files.pythonhosted.org/packages/81/05/7c73a9574cd4a53a25907bad38b59ac83919c0ddc8234ec157f344d57d9a/numpy-2.4.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da6cad4e82cb893db4b69105c604d805e0c3ce11501a55b5e9f9083b47d2ffe8", size = 15722394, upload-time = "2026-01-31T23:12:36.565Z" },
+    { url = "https://files.pythonhosted.org/packages/35/fa/4de10089f21fc7d18442c4a767ab156b25c2a6eaf187c0db6d9ecdaeb43f/numpy-2.4.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e4424677ce4b47fe73c8b5556d876571f7c6945d264201180db2dc34f676ab5", size = 16653343, upload-time = "2026-01-31T23:12:39.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f9/d33e4ffc857f3763a57aa85650f2e82486832d7492280ac21ba9efda80da/numpy-2.4.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2b8f157c8a6f20eb657e240f8985cc135598b2b46985c5bccbde7616dc9c6b1e", size = 17078045, upload-time = "2026-01-31T23:12:42.041Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b8/54bdb43b6225badbea6389fa038c4ef868c44f5890f95dd530a218706da3/numpy-2.4.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5daf6f3914a733336dab21a05cdec343144600e964d2fcdabaac0c0269874b2a", size = 18380024, upload-time = "2026-01-31T23:12:44.331Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/55/6e1a61ded7af8df04016d81b5b02daa59f2ea9252ee0397cb9f631efe9e5/numpy-2.4.2-cp314-cp314t-win32.whl", hash = "sha256:8c50dd1fc8826f5b26a5ee4d77ca55d88a895f4e4819c7ecc2a9f5905047a443", size = 6153937, upload-time = "2026-01-31T23:12:47.229Z" },
+    { url = "https://files.pythonhosted.org/packages/45/aa/fa6118d1ed6d776b0983f3ceac9b1a5558e80df9365b1c3aa6d42bf9eee4/numpy-2.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fcf92bee92742edd401ba41135185866f7026c502617f422eb432cfeca4fe236", size = 12631844, upload-time = "2026-01-31T23:12:48.997Z" },
+    { url = "https://files.pythonhosted.org/packages/32/0a/2ec5deea6dcd158f254a7b372fb09cfba5719419c8d66343bab35237b3fb/numpy-2.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:1f92f53998a17265194018d1cc321b2e96e900ca52d54c7c77837b71b9465181", size = 10565379, upload-time = "2026-01-31T23:12:51.345Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/48/aad6ec4f8d007534c091e9a7172b3ec1b1ee6d99a9cbb936b5eab6c6cf58/pandas-3.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5272627187b5d9c20e55d27caf5f2cd23e286aba25cadf73c8590e432e2b7262", size = 10317509, upload-time = "2026-02-17T22:18:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/14/5990826f779f79148ae9d3a2c39593dc04d61d5d90541e71b5749f35af95/pandas-3.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:661e0f665932af88c7877f31da0dc743fe9c8f2524bdffe23d24fdcb67ef9d56", size = 9860561, upload-time = "2026-02-17T22:19:02.265Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/80/f01ff54664b6d70fed71475543d108a9b7c888e923ad210795bef04ffb7d/pandas-3.0.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75e6e292ff898679e47a2199172593d9f6107fd2dd3617c22c2946e97d5df46e", size = 10365506, upload-time = "2026-02-17T22:19:05.017Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/85/ab6d04733a7d6ff32bfc8382bf1b07078228f5d6ebec5266b91bfc5c4ff7/pandas-3.0.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ff8cf1d2896e34343197685f432450ec99a85ba8d90cce2030c5eee2ef98791", size = 10873196, upload-time = "2026-02-17T22:19:07.204Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/9301c83d0b47c23ac5deab91c6b39fd98d5b5db4d93b25df8d381451828f/pandas-3.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eca8b4510f6763f3d37359c2105df03a7a221a508f30e396a51d0713d462e68a", size = 11370859, upload-time = "2026-02-17T22:19:09.436Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/0c1fc5bd2d29c7db2ab372330063ad555fb83e08422829c785f5ec2176ca/pandas-3.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06aff2ad6f0b94a17822cf8b83bbb563b090ed82ff4fe7712db2ce57cd50d9b8", size = 11924584, upload-time = "2026-02-17T22:19:11.562Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/7d/216a1588b65a7aa5f4535570418a599d943c85afb1d95b0876fc00aa1468/pandas-3.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:9fea306c783e28884c29057a1d9baa11a349bbf99538ec1da44c8476563d1b25", size = 9742769, upload-time = "2026-02-17T22:19:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/cb/810a22a6af9a4e97c8ab1c946b47f3489c5bca5adc483ce0ffc84c9cc768/pandas-3.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:a8d37a43c52917427e897cb2e429f67a449327394396a81034a4449b99afda59", size = 9043855, upload-time = "2026-02-17T22:19:16.09Z" },
+    { url = "https://files.pythonhosted.org/packages/92/fa/423c89086cca1f039cf1253c3ff5b90f157b5b3757314aa635f6bf3e30aa/pandas-3.0.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d54855f04f8246ed7b6fc96b05d4871591143c46c0b6f4af874764ed0d2d6f06", size = 10752673, upload-time = "2026-02-17T22:19:18.304Z" },
+    { url = "https://files.pythonhosted.org/packages/22/23/b5a08ec1f40020397f0faba72f1e2c11f7596a6169c7b3e800abff0e433f/pandas-3.0.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e1b677accee34a09e0dc2ce5624e4a58a1870ffe56fc021e9caf7f23cd7668f", size = 10404967, upload-time = "2026-02-17T22:19:20.726Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/81/94841f1bb4afdc2b52a99daa895ac2c61600bb72e26525ecc9543d453ebc/pandas-3.0.1-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9cabbdcd03f1b6cd254d6dda8ae09b0252524be1592594c00b7895916cb1324", size = 10320575, upload-time = "2026-02-17T22:19:24.919Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/8b/2ae37d66a5342a83adadfd0cb0b4bf9c3c7925424dd5f40d15d6cfaa35ee/pandas-3.0.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ae2ab1f166668b41e770650101e7090824fd34d17915dd9cd479f5c5e0065e9", size = 10710921, upload-time = "2026-02-17T22:19:27.181Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/61/772b2e2757855e232b7ccf7cb8079a5711becb3a97f291c953def15a833f/pandas-3.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6bf0603c2e30e2cafac32807b06435f28741135cb8697eae8b28c7d492fc7d76", size = 11334191, upload-time = "2026-02-17T22:19:29.411Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/08/b16c6df3ef555d8495d1d265a7963b65be166785d28f06a350913a4fac78/pandas-3.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6c426422973973cae1f4a23e51d4ae85974f44871b24844e4f7de752dd877098", size = 11782256, upload-time = "2026-02-17T22:19:32.34Z" },
+    { url = "https://files.pythonhosted.org/packages/55/80/178af0594890dee17e239fca96d3d8670ba0f5ff59b7d0439850924a9c09/pandas-3.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b03f91ae8c10a85c1613102c7bef5229b5379f343030a3ccefeca8a33414cf35", size = 10485047, upload-time = "2026-02-17T22:19:34.605Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/8b/4bb774a998b97e6c2fd62a9e6cfdaae133b636fd1c468f92afb4ae9a447a/pandas-3.0.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:99d0f92ed92d3083d140bf6b97774f9f13863924cf3f52a70711f4e7588f9d0a", size = 10322465, upload-time = "2026-02-17T22:19:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3a/5b39b51c64159f470f1ca3b1c2a87da290657ca022f7cd11442606f607d1/pandas-3.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3b66857e983208654294bb6477b8a63dee26b37bdd0eb34d010556e91261784f", size = 9910632, upload-time = "2026-02-17T22:19:39.001Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f7/b449ffb3f68c11da12fc06fbf6d2fa3a41c41e17d0284d23a79e1c13a7e4/pandas-3.0.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56cf59638bf24dc9bdf2154c81e248b3289f9a09a6d04e63608c159022352749", size = 10440535, upload-time = "2026-02-17T22:19:41.157Z" },
+    { url = "https://files.pythonhosted.org/packages/55/77/6ea82043db22cb0f2bbfe7198da3544000ddaadb12d26be36e19b03a2dc5/pandas-3.0.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1a9f55e0f46951874b863d1f3906dcb57df2d9be5c5847ba4dfb55b2c815249", size = 10893940, upload-time = "2026-02-17T22:19:43.493Z" },
+    { url = "https://files.pythonhosted.org/packages/03/30/f1b502a72468c89412c1b882a08f6eed8a4ee9dc033f35f65d0663df6081/pandas-3.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1849f0bba9c8a2fb0f691d492b834cc8dadf617e29015c66e989448d58d011ee", size = 11442711, upload-time = "2026-02-17T22:19:46.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f0/ebb6ddd8fc049e98cabac5c2924d14d1dda26a20adb70d41ea2e428d3ec4/pandas-3.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3d288439e11b5325b02ae6e9cc83e6805a62c40c5a6220bea9beb899c073b1c", size = 11963918, upload-time = "2026-02-17T22:19:48.838Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f8/8ce132104074f977f907442790eaae24e27bce3b3b454e82faa3237ff098/pandas-3.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:93325b0fe372d192965f4cca88d97667f49557398bbf94abdda3bf1b591dbe66", size = 9862099, upload-time = "2026-02-17T22:19:51.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b7/6af9aac41ef2456b768ef0ae60acf8abcebb450a52043d030a65b4b7c9bd/pandas-3.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:97ca08674e3287c7148f4858b01136f8bdfe7202ad25ad04fec602dd1d29d132", size = 9185333, upload-time = "2026-02-17T22:19:53.266Z" },
+    { url = "https://files.pythonhosted.org/packages/66/fc/848bb6710bc6061cb0c5badd65b92ff75c81302e0e31e496d00029fe4953/pandas-3.0.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:58eeb1b2e0fb322befcf2bbc9ba0af41e616abadb3d3414a6bc7167f6cbfce32", size = 10772664, upload-time = "2026-02-17T22:19:55.806Z" },
+    { url = "https://files.pythonhosted.org/packages/69/5c/866a9bbd0f79263b4b0db6ec1a341be13a1473323f05c122388e0f15b21d/pandas-3.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cd9af1276b5ca9e298bd79a26bda32fa9cc87ed095b2a9a60978d2ca058eaf87", size = 10421286, upload-time = "2026-02-17T22:19:58.091Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a4/2058fb84fb1cfbfb2d4a6d485e1940bb4ad5716e539d779852494479c580/pandas-3.0.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f87a04984d6b63788327cd9f79dda62b7f9043909d2440ceccf709249ca988", size = 10342050, upload-time = "2026-02-17T22:20:01.376Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1b/674e89996cc4be74db3c4eb09240c4bb549865c9c3f5d9b086ff8fcfbf00/pandas-3.0.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85fe4c4df62e1e20f9db6ebfb88c844b092c22cd5324bdcf94bfa2fc1b391221", size = 10740055, upload-time = "2026-02-17T22:20:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f8/e954b750764298c22fa4614376531fe63c521ef517e7059a51f062b87dca/pandas-3.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:331ca75a2f8672c365ae25c0b29e46f5ac0c6551fdace8eec4cd65e4fac271ff", size = 11357632, upload-time = "2026-02-17T22:20:06.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/02/c6e04b694ffd68568297abd03588b6d30295265176a5c01b7459d3bc35a3/pandas-3.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15860b1fdb1973fffade772fdb931ccf9b2f400a3f5665aef94a00445d7d8dd5", size = 11810974, upload-time = "2026-02-17T22:20:08.946Z" },
+    { url = "https://files.pythonhosted.org/packages/89/41/d7dfb63d2407f12055215070c42fc6ac41b66e90a2946cdc5e759058398b/pandas-3.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:44f1364411d5670efa692b146c748f4ed013df91ee91e9bec5677fb1fd58b937", size = 10884622, upload-time = "2026-02-17T22:20:11.711Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b0/34937815889fa982613775e4b97fddd13250f11012d769949c5465af2150/pandas-3.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:108dd1790337a494aa80e38def654ca3f0968cf4f362c85f44c15e471667102d", size = 9452085, upload-time = "2026-02-17T22:20:14.331Z" },
 ]
 
 [[package]]
@@ -321,6 +423,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -382,6 +496,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -403,6 +526,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
 name = "upbeat"
 version = "0.0.0"
 source = { editable = "." }
@@ -413,9 +545,15 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.optional-dependencies]
+pandas = [
+    { name = "pandas" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pandas" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -425,14 +563,17 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pyjwt", specifier = ">=2.11.0" },
     { name = "websockets", specifier = ">=16.0" },
 ]
+provides-extras = ["pandas"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.19.1" },
+    { name = "pandas", specifier = ">=2.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.15.5" },


### PR DESCRIPTION
## Summary
- `upbeat[pandas]` optional dependency로 pandas 추가 (`pyproject.toml`)
- `candles_to_dataframe()` 유틸리티 함수 (`_pandas.py`) — OHLCV 컬럼 매핑, `DatetimeIndex(utc=True)`, 빈 리스트 처리
- `QuotationAPI` / `AsyncQuotationAPI`에 `_df` 메서드 12개 추가 (`get_candles_minutes_df` 등)
- `get_candles_df()` 편의 함수 및 모듈 export 추가
- 24개 테스트 추가 (DataFrame 검증, ImportError 메시지, 라우팅)

Closes #26

## Test plan
- [x] `uv run pytest tests/test_pandas.py -v` — 24 passed
- [x] `uv run pytest -v` — 전체 316 passed (회귀 없음)
- [x] `uv run ruff check` — 수정 파일 lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)