### PR TITLE
feat: get_chance() 결과 per-market TTL 캐시 추가

### DIFF
--- a/src/upbeat/api/orders.py
+++ b/src/upbeat/api/orders.py
@@ -61,6 +61,7 @@ class OrdersAPI(_SyncAPIResource):
             value, expiry = entry
             if time.monotonic() < expiry:
                 return value
+            del self._min_total_cache[market]
         return None
 
     def _check_min_order(
@@ -350,6 +351,7 @@ class AsyncOrdersAPI(_AsyncAPIResource):
             value, expiry = entry
             if time.monotonic() < expiry:
                 return value
+            del self._min_total_cache[market]
         return None
 
     async def _check_min_order(

--- a/src/upbeat/api/orders.py
+++ b/src/upbeat/api/orders.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from decimal import Decimal
 from typing import Any
 
@@ -35,6 +36,9 @@ def _compute_bid_total(
     return Decimal(price)
 
 
+_DEFAULT_MIN_TOTAL_TTL: float = 60.0
+
+
 class OrdersAPI(_SyncAPIResource):
     _validate_min_order: bool
 
@@ -44,9 +48,20 @@ class OrdersAPI(_SyncAPIResource):
         credentials: Credentials | None,
         *,
         validate_min_order: bool = False,
+        min_total_ttl: float = _DEFAULT_MIN_TOTAL_TTL,
     ) -> None:
         super().__init__(transport, credentials)
         self._validate_min_order = validate_min_order
+        self._min_total_ttl = min_total_ttl
+        self._min_total_cache: dict[str, tuple[str, float]] = {}
+
+    def _get_cached_min_total(self, market: str) -> str | None:
+        entry = self._min_total_cache.get(market)
+        if entry is not None:
+            value, expiry = entry
+            if time.monotonic() < expiry:
+                return value
+        return None
 
     def _check_min_order(
         self,
@@ -61,8 +76,25 @@ class OrdersAPI(_SyncAPIResource):
         total = _compute_bid_total(price, volume, ord_type)
         if total is None:
             return
+
+        cached = self._get_cached_min_total(market)
+        if cached is not None:
+            min_total = Decimal(cached)
+            if total < min_total:
+                raise ValidationError(
+                    f"Order total {total} is below minimum {min_total} for {market}",
+                    market=market,
+                    total=str(total),
+                    min_total=cached,
+                )
+            return
+
         chance = self.get_chance(market=market)
         if chance.market.bid is not None:
+            self._min_total_cache[market] = (
+                chance.market.bid.min_total,
+                time.monotonic() + self._min_total_ttl,
+            )
             min_total = Decimal(chance.market.bid.min_total)
             if total < min_total:
                 raise ValidationError(
@@ -305,9 +337,20 @@ class AsyncOrdersAPI(_AsyncAPIResource):
         credentials: Credentials | None,
         *,
         validate_min_order: bool = False,
+        min_total_ttl: float = _DEFAULT_MIN_TOTAL_TTL,
     ) -> None:
         super().__init__(transport, credentials)
         self._validate_min_order = validate_min_order
+        self._min_total_ttl = min_total_ttl
+        self._min_total_cache: dict[str, tuple[str, float]] = {}
+
+    def _get_cached_min_total(self, market: str) -> str | None:
+        entry = self._min_total_cache.get(market)
+        if entry is not None:
+            value, expiry = entry
+            if time.monotonic() < expiry:
+                return value
+        return None
 
     async def _check_min_order(
         self,
@@ -322,8 +365,25 @@ class AsyncOrdersAPI(_AsyncAPIResource):
         total = _compute_bid_total(price, volume, ord_type)
         if total is None:
             return
+
+        cached = self._get_cached_min_total(market)
+        if cached is not None:
+            min_total = Decimal(cached)
+            if total < min_total:
+                raise ValidationError(
+                    f"Order total {total} is below minimum {min_total} for {market}",
+                    market=market,
+                    total=str(total),
+                    min_total=cached,
+                )
+            return
+
         chance = await self.get_chance(market=market)
         if chance.market.bid is not None:
+            self._min_total_cache[market] = (
+                chance.market.bid.min_total,
+                time.monotonic() + self._min_total_ttl,
+            )
             min_total = Decimal(chance.market.bid.min_total)
             if total < min_total:
                 raise ValidationError(

--- a/tests/api/test_orders.py
+++ b/tests/api/test_orders.py
@@ -732,7 +732,7 @@ class TestMinOrderCache:
 
         transport = _make_transport(handler)
         api = OrdersAPI(
-            transport, CREDENTIALS, validate_min_order=True, min_total_ttl=0.0
+            transport, CREDENTIALS, validate_min_order=True, min_total_ttl=-1.0
         )
         api.create(market="KRW-BTC", side="bid", ord_type="price", price="6000")
         api.create(market="KRW-BTC", side="bid", ord_type="price", price="6000")

--- a/tests/api/test_orders.py
+++ b/tests/api/test_orders.py
@@ -700,3 +700,98 @@ class TestMinOrderValidation:
             market="KRW-BTC", side="bid", ord_type="price", price="6000"
         )
         assert isinstance(result, OrderCreated)
+
+
+# ── TestMinOrderCache ──────────────────────────────────────────────────
+
+
+class TestMinOrderCache:
+    def test_cache_hit_skips_get_chance(self) -> None:
+        chance_calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal chance_calls
+            if request.url.path == "/v1/orders/chance":
+                chance_calls += 1
+            return _multi_handler(request)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS, validate_min_order=True)
+        api.create(market="KRW-BTC", side="bid", ord_type="price", price="6000")
+        api.create(market="KRW-BTC", side="bid", ord_type="price", price="6000")
+        assert chance_calls == 1
+
+    def test_cache_expires_after_ttl(self) -> None:
+        chance_calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal chance_calls
+            if request.url.path == "/v1/orders/chance":
+                chance_calls += 1
+            return _multi_handler(request)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(
+            transport, CREDENTIALS, validate_min_order=True, min_total_ttl=0.0
+        )
+        api.create(market="KRW-BTC", side="bid", ord_type="price", price="6000")
+        api.create(market="KRW-BTC", side="bid", ord_type="price", price="6000")
+        assert chance_calls == 2
+
+    def test_cache_is_per_market(self) -> None:
+        chance_calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal chance_calls
+            if request.url.path == "/v1/orders/chance":
+                chance_calls += 1
+            return _multi_handler(request)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS, validate_min_order=True)
+        api.create(market="KRW-BTC", side="bid", ord_type="price", price="6000")
+        api.create(market="KRW-ETH", side="bid", ord_type="price", price="6000")
+        assert chance_calls == 2
+
+    def test_cache_hit_still_validates(self) -> None:
+        transport = _make_transport(_multi_handler)
+        api = OrdersAPI(transport, CREDENTIALS, validate_min_order=True)
+        # First call populates the cache
+        api.create(market="KRW-BTC", side="bid", ord_type="price", price="6000")
+        # Second call should use cache but still raise for low total
+        with pytest.raises(ValidationError) as exc_info:
+            api.create(market="KRW-BTC", side="bid", ord_type="price", price="3000")
+        assert exc_info.value.min_total == "5000"
+
+    def test_cache_populated_on_validation_failure(self) -> None:
+        chance_calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal chance_calls
+            if request.url.path == "/v1/orders/chance":
+                chance_calls += 1
+            return _multi_handler(request)
+
+        transport = _make_transport(handler)
+        api = OrdersAPI(transport, CREDENTIALS, validate_min_order=True)
+        with pytest.raises(ValidationError):
+            api.create(market="KRW-BTC", side="bid", ord_type="price", price="3000")
+        with pytest.raises(ValidationError):
+            api.create(market="KRW-BTC", side="bid", ord_type="price", price="3000")
+        assert chance_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_async_cache_hit_skips_get_chance(self) -> None:
+        chance_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal chance_calls
+            if request.url.path == "/v1/orders/chance":
+                chance_calls += 1
+            return _multi_handler(request)
+
+        transport = _make_async_transport(handler)
+        api = AsyncOrdersAPI(transport, CREDENTIALS, validate_min_order=True)
+        await api.create(market="KRW-BTC", side="bid", ord_type="price", price="6000")
+        await api.create(market="KRW-BTC", side="bid", ord_type="price", price="6000")
+        assert chance_calls == 1


### PR DESCRIPTION
## Summary
- `OrdersAPI` / `AsyncOrdersAPI`에 마켓별 `min_total` TTL 캐시 도입 (기본 60초)
- `validate_min_order=True`일 때 동일 마켓 반복 주문 시 `get_chance()` API 호출을 캐시로 대체하여 레이트 리밋 소진 방지
- 캐시 히트, TTL 만료, per-market 격리, 검증 실패 시에도 캐시 저장 등 6개 테스트 추가

Closes #45

## Test plan
- [x] `uv run pytest tests/api/test_orders.py -v` — 기존 38개 테스트 + 신규 6개 모두 통과
- [x] `uv run ruff check src/upbeat/api/orders.py` — 린트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)